### PR TITLE
Fix master template for Travis CI composer caching

### DIFF
--- a/templates/plugin-travis.mustache
+++ b/templates/plugin-travis.mustache
@@ -12,8 +12,9 @@ branches:
     - master
 
 cache:
-  - composer
-  - $HOME/.composer/cache
+  directories:
+    - vendor
+    - $HOME/.composer/cache
 
 matrix:
   include:


### PR DESCRIPTION
See https://github.com/wp-cli/media-command/issues/11