### PR TITLE
Use path relative to command to retrieve templates.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_install:
   - phpenv config-rm xdebug.ini
 
 install:
-  - composer require wp-cli/wp-cli:dev-phar-safe-path
+  - composer require wp-cli/wp-cli:dev-phar-safe-dir
   - composer install
   - bash bin/install-package-tests.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_install:
   - phpenv config-rm xdebug.ini
 
 install:
-  - composer require wp-cli/wp-cli:dev-master
+  - composer require wp-cli/wp-cli:dev-phar-safe-path
   - composer install
   - bash bin/install-package-tests.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_install:
   - phpenv config-rm xdebug.ini
 
 install:
-  - composer require wp-cli/wp-cli:dev-phar-safe-dir
+  - composer require wp-cli/wp-cli:dev-master
   - composer install
   - bash bin/install-package-tests.sh
 

--- a/src/Scaffold_Command.php
+++ b/src/Scaffold_Command.php
@@ -995,14 +995,13 @@ class Scaffold_Command extends WP_CLI_Command {
 	 * Get template path based on installation type
 	 */
 	private static function get_template_path( $template ) {
-		$template_path = WP_CLI_ROOT . '/vendor/wp-cli/scaffold-command/templates/' . $template;
+		$command_root = Utils\phar_safe_path( dirname( __DIR__ ) );
+		$template_path = "{$command_root}/templates/{$template}";
+
 		if ( ! file_exists( $template_path ) ) {
-			// scaffold command must've been built with vendor/wp-cli/wp-cli
-			$template_path = WP_CLI_ROOT . '/../../../templates/' . $template;
-			if ( ! file_exists( $template_path ) ) {
-				WP_CLI::error( "Couldn't find {$template}" );
-			}
+			WP_CLI::error( "Couldn't find {$template}" );
 		}
+
 		return $template_path;
 	}
 


### PR DESCRIPTION
Instead of relating the `/templates/` path to the (relatively) shifting WP-CLI framework, relate it to the command's root folder instead.

See #10