### PR TITLE
Cater for symbolic links. Add canonicalize_path and use in check_target_directory.

### DIFF
--- a/features/scaffold-plugin-tests.feature
+++ b/features/scaffold-plugin-tests.feature
@@ -145,19 +145,19 @@ Feature: Scaffold plugin unit tests
     When I try `wp scaffold plugin-tests hello`
     Then STDERR should be:
       """
-      Error: Invalid plugin slug specified. No such target directory "{RUN_DIR}/wp-content/plugins/hello".
+      Error: Invalid plugin slug specified. No such target directory '{RUN_DIR}/wp-content/plugins/hello'.
       """
 
     When I try `wp scaffold plugin-tests .`
     Then STDERR should be:
       """
-      Error: Invalid plugin slug specified. The slug cannot be "." or "..".
+      Error: Invalid plugin slug specified. The slug cannot be '.' or '..'.
       """
 
     When I try `wp scaffold plugin-tests ../`
     Then STDERR should be:
       """
-      Error: Invalid plugin slug specified. The target directory "{RUN_DIR}/wp-content/plugins/../" is not in "{RUN_DIR}/wp-content/plugins".
+      Error: Invalid plugin slug specified. The target directory '{RUN_DIR}/wp-content/plugins/../' is not in '{RUN_DIR}/wp-content/plugins'.
       """
 
   Scenario: Scaffold plugin tests with invalid directory
@@ -170,7 +170,7 @@ Feature: Scaffold plugin unit tests
     When I try `wp scaffold plugin-tests hello-world --dir=non-existent-dir`
     Then STDERR should be:
       """
-      Error: Invalid plugin directory specified. No such directory "non-existent-dir".
+      Error: Invalid plugin directory specified. No such directory 'non-existent-dir'.
       """
 
     When I run `rm -rf {PLUGIN_DIR} && touch {PLUGIN_DIR}`
@@ -178,7 +178,7 @@ Feature: Scaffold plugin unit tests
     When I try `wp scaffold plugin-tests hello-world`
     Then STDERR should be:
       """
-      Error: Invalid plugin slug specified. No such target directory "{PLUGIN_DIR}".
+      Error: Invalid plugin slug specified. No such target directory '{PLUGIN_DIR}'.
       """
 
   Scenario: Scaffold plugin tests with a symbolic link
@@ -192,7 +192,7 @@ Feature: Scaffold plugin unit tests
     Then the return code should be 0
 
     When I run `wp scaffold plugin-tests hello-world`
-    And STDOUT should not be empty
+    Then STDOUT should not be empty
     And the {PLUGIN_DIR}/tests directory should contain:
       """
       bootstrap.php

--- a/features/scaffold-plugin-tests.feature
+++ b/features/scaffold-plugin-tests.feature
@@ -140,7 +140,7 @@ Feature: Scaffold plugin unit tests
 
   Scenario: Scaffold plugin tests with invalid slug
     Given a WP install
-	Then the {RUN_DIR}/wp-content/plugins/hello.php file should exist
+    Then the {RUN_DIR}/wp-content/plugins/hello.php file should exist
 
     When I try `wp scaffold plugin-tests hello`
     Then STDERR should be:
@@ -174,7 +174,7 @@ Feature: Scaffold plugin unit tests
       """
 
     When I run `rm -rf {PLUGIN_DIR} && touch {PLUGIN_DIR}`
-	Then the return code should be 0
+    Then the return code should be 0
     When I try `wp scaffold plugin-tests hello-world`
     Then STDERR should be:
       """
@@ -188,8 +188,8 @@ Feature: Scaffold plugin unit tests
     When I run `wp plugin path hello-world --dir`
     Then save STDOUT as {PLUGIN_DIR}
 
-	When I run `mv {PLUGIN_DIR} {RUN_DIR} && ln -s {RUN_DIR}/hello-world {PLUGIN_DIR}`
-	Then the return code should be 0
+    When I run `mv {PLUGIN_DIR} {RUN_DIR} && ln -s {RUN_DIR}/hello-world {PLUGIN_DIR}`
+    Then the return code should be 0
 
     When I run `wp scaffold plugin-tests hello-world`
     And STDOUT should not be empty

--- a/features/scaffold-theme-tests.feature
+++ b/features/scaffold-theme-tests.feature
@@ -77,7 +77,7 @@ Feature: Scaffold theme unit tests
     When I try `wp scaffold theme-tests p3child`
     Then STDERR should be:
       """
-      Error: Invalid theme slug specified.
+      Error: Invalid theme slug specified. The theme "p3child" does not exist.
       """
 
   Scenario: Scaffold theme tests with Circle as the provider
@@ -101,14 +101,50 @@ Feature: Scaffold theme unit tests
   Scenario: Scaffold theme tests with invalid slug
 
     When I try `wp scaffold theme-tests .`
-    Then STDERR should contain:
+    Then STDERR should be:
       """
-      Error: Invalid theme slug specified.
+      Error: Invalid theme slug specified. The slug cannot be "." or "..".
       """
 
     When I try `wp scaffold theme-tests ../`
-    Then STDERR should contain:
+    Then STDERR should be:
       """
-      Error: Invalid theme slug specified.
+      Error: Invalid theme slug specified. The target directory "{RUN_DIR}/wp-content/themes/../" is not in "{RUN_DIR}/wp-content/themes".
       """
 
+  Scenario: Scaffold theme tests with invalid directory
+    When I try `wp scaffold theme-tests p2 --dir=non-existent-dir`
+    Then STDERR should be:
+      """
+      Error: Invalid theme directory specified. No such directory "non-existent-dir".
+      """
+
+	# Temporarily move.
+    When I run `mv -f {THEME_DIR}/p2 {THEME_DIR}/hide-p2 && touch {THEME_DIR}/p2`
+	Then the return code should be 0
+
+    When I try `wp scaffold theme-tests p2`
+    Then STDERR should be:
+      """
+      Error: Invalid theme slug specified. No such target directory "{THEME_DIR}/p2".
+      """
+
+	# Restore.
+    When I run `rm -f {THEME_DIR}/p2 && mv -f {THEME_DIR}/hide-p2 {THEME_DIR}/p2`
+	Then the return code should be 0
+
+  Scenario: Scaffold theme tests with a symbolic link
+	# Temporarily move the whole theme dir and create a symbolic link to it.
+	When I run `mv -f {THEME_DIR} {RUN_DIR}/alt-themes && ln -s {RUN_DIR}/alt-themes {THEME_DIR}`
+	Then the return code should be 0
+
+    When I run `wp scaffold theme-tests p2`
+    And STDOUT should not be empty
+    And the {THEME_DIR}/p2/tests directory should contain:
+      """
+      bootstrap.php
+      """
+
+	# Restore.
+    When I run `unlink {THEME_DIR} && mv -f {RUN_DIR}/alt-themes {THEME_DIR}`
+	Then the return code should be 0

--- a/features/scaffold-theme-tests.feature
+++ b/features/scaffold-theme-tests.feature
@@ -119,9 +119,9 @@ Feature: Scaffold theme unit tests
       Error: Invalid theme directory specified. No such directory "non-existent-dir".
       """
 
-	# Temporarily move.
+    # Temporarily move.
     When I run `mv -f {THEME_DIR}/p2 {THEME_DIR}/hide-p2 && touch {THEME_DIR}/p2`
-	Then the return code should be 0
+    Then the return code should be 0
 
     When I try `wp scaffold theme-tests p2`
     Then STDERR should be:
@@ -129,14 +129,14 @@ Feature: Scaffold theme unit tests
       Error: Invalid theme slug specified. No such target directory "{THEME_DIR}/p2".
       """
 
-	# Restore.
+    # Restore.
     When I run `rm -f {THEME_DIR}/p2 && mv -f {THEME_DIR}/hide-p2 {THEME_DIR}/p2`
-	Then the return code should be 0
+    Then the return code should be 0
 
   Scenario: Scaffold theme tests with a symbolic link
-	# Temporarily move the whole theme dir and create a symbolic link to it.
-	When I run `mv -f {THEME_DIR} {RUN_DIR}/alt-themes && ln -s {RUN_DIR}/alt-themes {THEME_DIR}`
-	Then the return code should be 0
+    # Temporarily move the whole theme dir and create a symbolic link to it.
+    When I run `mv -f {THEME_DIR} {RUN_DIR}/alt-themes && ln -s {RUN_DIR}/alt-themes {THEME_DIR}`
+    Then the return code should be 0
 
     When I run `wp scaffold theme-tests p2`
     And STDOUT should not be empty
@@ -145,6 +145,6 @@ Feature: Scaffold theme unit tests
       bootstrap.php
       """
 
-	# Restore.
+    # Restore.
     When I run `unlink {THEME_DIR} && mv -f {RUN_DIR}/alt-themes {THEME_DIR}`
-	Then the return code should be 0
+    Then the return code should be 0

--- a/features/scaffold-theme-tests.feature
+++ b/features/scaffold-theme-tests.feature
@@ -77,7 +77,7 @@ Feature: Scaffold theme unit tests
     When I try `wp scaffold theme-tests p3child`
     Then STDERR should be:
       """
-      Error: Invalid theme slug specified. The theme "p3child" does not exist.
+      Error: Invalid theme slug specified. The theme 'p3child' does not exist.
       """
 
   Scenario: Scaffold theme tests with Circle as the provider
@@ -103,20 +103,20 @@ Feature: Scaffold theme unit tests
     When I try `wp scaffold theme-tests .`
     Then STDERR should be:
       """
-      Error: Invalid theme slug specified. The slug cannot be "." or "..".
+      Error: Invalid theme slug specified. The slug cannot be '.' or '..'.
       """
 
     When I try `wp scaffold theme-tests ../`
     Then STDERR should be:
       """
-      Error: Invalid theme slug specified. The target directory "{RUN_DIR}/wp-content/themes/../" is not in "{RUN_DIR}/wp-content/themes".
+      Error: Invalid theme slug specified. The target directory '{RUN_DIR}/wp-content/themes/../' is not in '{RUN_DIR}/wp-content/themes'.
       """
 
   Scenario: Scaffold theme tests with invalid directory
     When I try `wp scaffold theme-tests p2 --dir=non-existent-dir`
     Then STDERR should be:
       """
-      Error: Invalid theme directory specified. No such directory "non-existent-dir".
+      Error: Invalid theme directory specified. No such directory 'non-existent-dir'.
       """
 
     # Temporarily move.
@@ -126,7 +126,7 @@ Feature: Scaffold theme unit tests
     When I try `wp scaffold theme-tests p2`
     Then STDERR should be:
       """
-      Error: Invalid theme slug specified. No such target directory "{THEME_DIR}/p2".
+      Error: Invalid theme slug specified. No such target directory '{THEME_DIR}/p2'.
       """
 
     # Restore.
@@ -139,7 +139,7 @@ Feature: Scaffold theme unit tests
     Then the return code should be 0
 
     When I run `wp scaffold theme-tests p2`
-    And STDOUT should not be empty
+    Then STDOUT should not be empty
     And the {THEME_DIR}/p2/tests directory should contain:
       """
       bootstrap.php

--- a/src/Scaffold_Command.php
+++ b/src/Scaffold_Command.php
@@ -793,7 +793,7 @@ class Scaffold_Command extends WP_CLI_Command {
 	 * @return null|string Returns null on success, error message on error.
 	 */
 	private function check_target_directory( $type, $target_dir ) {
-		$parent_dir = dirname( Utils\canonicalize_path( str_replace( '\\', '/', $target_dir ) ) );
+		$parent_dir = dirname( self::canonicalize_path( str_replace( '\\', '/', $target_dir ) ) );
 
 		if ( 'theme' === $type && str_replace( '\\', '/', WP_CONTENT_DIR . '/themes' ) !== $parent_dir ) {
 			return sprintf( 'The target directory "%1$s" is not in "%2$s".', $target_dir, WP_CONTENT_DIR . '/themes' );
@@ -1005,4 +1005,35 @@ class Scaffold_Command extends WP_CLI_Command {
 		return $template_path;
 	}
 
+	/*
+	 * Returns the canonicalized path, with dot and double dot segments resolved.
+	 *
+	 * Copied from Symfony\Component\DomCrawler\AbstractUriElement::canonicalizePath().
+	 * Implements RFC 3986, section 5.2.4.
+	 *
+	 * @param string $path The path to make canonical.
+	 *
+	 * @return string The canonicalized path.
+	 */
+	private static function canonicalize_path( $path ) {
+		if ( '' === $path || '/' === $path ) {
+			return $path;
+		}
+
+		if ( '.' === substr( $path, -1 ) ) {
+			$path .= '/';
+		}
+
+		$output = array();
+
+		foreach ( explode( '/', $path ) as $segment ) {
+			if ( '..' === $segment ) {
+				array_pop( $output );
+			} elseif ( '.' !== $segment ) {
+				$output[] = $segment;
+			}
+		}
+
+		return implode( '/', $output );
+	}
 }

--- a/src/Scaffold_Command.php
+++ b/src/Scaffold_Command.php
@@ -785,7 +785,7 @@ class Scaffold_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Checks that the `$target_dir` is a child directory of the themes or plugins directory, depending on `$type`.
+	 * Checks that the `$target_dir` is a child directory of the WP themes or plugins directory, depending on `$type`.
 	 *
 	 * @param string $type       "theme" or "plugin"
 	 * @param string $target_dir The theme/plugin directory to check.

--- a/src/Scaffold_Command.php
+++ b/src/Scaffold_Command.php
@@ -362,7 +362,7 @@ class Scaffold_Command extends WP_CLI_Command {
 		$theme_slug = $args[0];
 
 		if ( in_array( $theme_slug, array( '.', '..' ) ) ) {
-			WP_CLI::error( "Invalid theme slug specified. The slug cannot be \".\" or \"..\"." );
+			WP_CLI::error( "Invalid theme slug specified. The slug cannot be '.' or '..'." );
 		}
 
 		$data = wp_parse_args( $assoc_args, array(
@@ -508,7 +508,7 @@ class Scaffold_Command extends WP_CLI_Command {
 		$plugin_package = str_replace( ' ', '_', $plugin_name );
 
 		if ( in_array( $plugin_slug, array( '.', '..' ) ) ) {
-			WP_CLI::error( "Invalid plugin slug specified. The slug cannot be \".\" or \"..\"." );
+			WP_CLI::error( "Invalid plugin slug specified. The slug cannot be '.' or '..'." );
 		}
 
 		$data = wp_parse_args( $assoc_args, array(
@@ -680,20 +680,20 @@ class Scaffold_Command extends WP_CLI_Command {
 		if ( ! empty( $args[0] ) ) {
 			$slug = $args[0];
 			if ( in_array( $slug, array( '.', '..' ) ) ) {
-				WP_CLI::error( "Invalid {$type} slug specified. The slug cannot be \".\" or \"..\"." );
+				WP_CLI::error( "Invalid {$type} slug specified. The slug cannot be '.' or '..'." );
 			}
 			if ( 'theme' === $type ) {
 				$theme = wp_get_theme( $slug );
 				if ( $theme->exists() ) {
 					$target_dir = $theme->get_stylesheet_directory();
 				} else {
-					WP_CLI::error( "Invalid {$type} slug specified. The theme \"{$slug}\" does not exist." );
+					WP_CLI::error( "Invalid {$type} slug specified. The theme '{$slug}' does not exist." );
 				}
 			} else {
 				$target_dir = WP_PLUGIN_DIR . "/$slug";
 			}
 			if ( empty( $assoc_args['dir'] ) && ! is_dir( $target_dir ) ) {
-				WP_CLI::error( "Invalid {$type} slug specified. No such target directory \"{$target_dir}\"." );
+				WP_CLI::error( "Invalid {$type} slug specified. No such target directory '{$target_dir}'." );
 			}
 			if ( $error_msg = $this->check_target_directory( $type, $target_dir ) ) {
 				WP_CLI::error( "Invalid {$type} slug specified. {$error_msg}" );
@@ -703,7 +703,7 @@ class Scaffold_Command extends WP_CLI_Command {
 		if ( ! empty( $assoc_args['dir'] ) ) {
 			$target_dir = $assoc_args['dir'];
 			if ( ! is_dir( $target_dir ) ) {
-				WP_CLI::error( "Invalid {$type} directory specified. No such directory \"{$target_dir}\"." );
+				WP_CLI::error( "Invalid {$type} directory specified. No such directory '{$target_dir}'." );
 			}
 			if ( empty( $slug ) ) {
 				$slug = Utils\basename( $target_dir );
@@ -796,11 +796,11 @@ class Scaffold_Command extends WP_CLI_Command {
 		$parent_dir = dirname( self::canonicalize_path( str_replace( '\\', '/', $target_dir ) ) );
 
 		if ( 'theme' === $type && str_replace( '\\', '/', WP_CONTENT_DIR . '/themes' ) !== $parent_dir ) {
-			return sprintf( 'The target directory "%1$s" is not in "%2$s".', $target_dir, WP_CONTENT_DIR . '/themes' );
+			return sprintf( 'The target directory \'%1$s\' is not in \'%2$s\'.', $target_dir, WP_CONTENT_DIR . '/themes' );
 		}
 
 		if ( 'plugin' === $type && str_replace( '\\', '/', WP_PLUGIN_DIR ) !== $parent_dir ) {
-			return sprintf( 'The target directory "%1$s" is not in "%2$s".', $target_dir, WP_PLUGIN_DIR );
+			return sprintf( 'The target directory \'%1$s\' is not in \'%2$s\'.', $target_dir, WP_PLUGIN_DIR );
 		}
 
 		// Success.


### PR DESCRIPTION
Issue https://github.com/wp-cli/scaffold-command/issues/22

Adds `canonicalize_path()` and uses in `check_target_directory()` in place of `realpath()` to avoid symbolic link issues.

Adds some feedback by appending various reasons to the "Invalid plugin/theme slug specified." error messages. Involves changing `check_target_directory()` to return error string instead of bool.