### PR TITLE
Change the grunt config for addtextdomain to override all text domains by default

### DIFF
--- a/templates/plugin-gruntfile.mustache
+++ b/templates/plugin-gruntfile.mustache
@@ -11,10 +11,11 @@ module.exports = function( grunt ) {
 			options: {
 				textdomain: '{{textdomain}}',
 			},
-			target: {
-				files: {
-					src: [ '*.php', '**/*.php', '!node_modules/**', '!php-tests/**', '!bin/**' ]
-				}
+			update_all_domains: {
+				options: {
+					updateDomains: true
+				},
+				src: [ '*.php', '**/*.php', '!node_modules/**', '!php-tests/**', '!bin/**' ]
 			}
 		},
 


### PR DESCRIPTION
Related issue - #27 

Changed the grunt config for addtextdomain to override all text domains by default, instead of just appending to all i18n functions.