### PR TITLE
Use branches instead of tags for test library when two digit WP versions are used

### DIFF
--- a/templates/install-wp-tests.sh
+++ b/templates/install-wp-tests.sh
@@ -23,7 +23,9 @@ download() {
     fi
 }
 
-if [[ $WP_VERSION =~ [0-9]+\.[0-9]+(\.[0-9]+)? ]]; then
+if [[ $WP_VERSION =~ [0-9]+\.[0-9]+ ]]; then
+	WP_TESTS_TAG="branches/$WP_VERSION"
+elif [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0-9]+ ]]; then
 	WP_TESTS_TAG="tags/$WP_VERSION"
 elif [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
 	WP_TESTS_TAG="trunk"


### PR DESCRIPTION
From #18:

> In install-wp-tests.sh the tags directory of the core test suite is used. For example, calling install-wp-tests.sh <name> <user> <pass> <host> 4.7 results in the tags/4.7 directory of the test suite being checked out.
> 
> The disadvantage of this is that any fixes which get made to the test infrastructure in branch point releases don't get picked up by the test install script. For example, specifying a WordPress version of 4.7 checks out the test suite for 4.7, but doesn't include the recent changes in 4.7.1 - 4.7.5.

This pull adds the change that @johnbillion made in his plugin to fix the tests repo version.

Still need to add code to use the branch for the actual WordPress code.