### PR TITLE
Use latest branch for test library, and always get the latest major release when 2 digit wp versions are used

### DIFF
--- a/templates/install-wp-tests.sh
+++ b/templates/install-wp-tests.sh
@@ -78,7 +78,7 @@ install_wp() {
 			if [[ -z "$LATEST_VERSION" ]]; then
 				local ARCHIVE_NAME="wordpress-$WP_VERSION"
 			else
-				ARCHIVE_NAME="wordpress-$LATEST_VERSION"
+				local ARCHIVE_NAME="wordpress-$LATEST_VERSION"
 			fi
 		else
 			local ARCHIVE_NAME="wordpress-$WP_VERSION"

--- a/templates/install-wp-tests.sh
+++ b/templates/install-wp-tests.sh
@@ -69,7 +69,7 @@ install_wp() {
 			download https://api.wordpress.org/core/version-check/1.7/ /tmp/wp-latest.json
 			if [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0] ]]; then
 				# version x.x.0 means the first release of the major version, so strip off the .0 and download version x.x
-				WP_VERSION=${WP_VERSION%??}
+				LATEST_VERSION=${WP_VERSION%??}
 			else
 				# otherwise, scan the releases and get the most up to date minor version of the major release
 				local VERSION_ESCAPED=`echo $WP_VERSION | sed 's/\./\\\\./g'`

--- a/templates/install-wp-tests.sh
+++ b/templates/install-wp-tests.sh
@@ -28,7 +28,7 @@ if [[ $WP_VERSION =~ ^[0-9]+\.[0-9]+$ ]]; then
 elif [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0-9]+ ]]; then
 	if [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0] ]]; then
 		# version x.x.0 means the first release of the major version, so strip off the .0 and download version x.x
-		WP_TESTS_TAG="branches/${WP_VERSION%??}"
+		WP_TESTS_TAG="tags/${WP_VERSION%??}"
 	else
 		WP_TESTS_TAG="tags/$WP_VERSION"
 	fi

--- a/templates/install-wp-tests.sh
+++ b/templates/install-wp-tests.sh
@@ -23,8 +23,15 @@ download() {
     fi
 }
 
-if [[ $WP_VERSION =~ [0-9]+\.[0-9]+(\.[0-9]+)? ]]; then
-	WP_TESTS_TAG="tags/$WP_VERSION"
+if [[ $WP_VERSION =~ ^[0-9]+\.[0-9]+$ ]]; then
+	WP_TESTS_TAG="branches/$WP_VERSION"
+elif [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0-9]+ ]]; then
+	if [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0] ]]; then
+		# version x.x.0 means the first release of the major version, so strip off the .0 and download version x.x
+		WP_TESTS_TAG="branches/${WP_VERSION%??}"
+	else
+		WP_TESTS_TAG="tags/$WP_VERSION"
+	fi
 elif [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
 	WP_TESTS_TAG="trunk"
 else
@@ -57,6 +64,22 @@ install_wp() {
 	else
 		if [ $WP_VERSION == 'latest' ]; then
 			local ARCHIVE_NAME='latest'
+		elif [[ $WP_VERSION =~ [0-9]+\.[0-9]+ ]]; then
+			# https serves multiple offers, whereas http serves single.
+			download https://api.wordpress.org/core/version-check/1.7/ /tmp/wp-latest.json
+			if [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0] ]]; then
+				# version x.x.0 means the first release of the major version, so strip off the .0 and download version x.x
+				WP_VERSION=${WP_VERSION%??}
+			else
+				# otherwise, scan the releases and get the most up to date minor version of the major release
+				local VERSION_ESCAPED=`echo $WP_VERSION | sed 's/\./\\\\./g'`
+				LATEST_VERSION=$(grep -o '"version":"'$VERSION_ESCAPED'[^"]*' /tmp/wp-latest.json | sed 's/"version":"//' | head -1)
+			fi
+			if [[ -z "$LATEST_VERSION" ]]; then
+				local ARCHIVE_NAME="wordpress-$WP_VERSION"
+			else
+				ARCHIVE_NAME="wordpress-$LATEST_VERSION"
+			fi
 		else
 			local ARCHIVE_NAME="wordpress-$WP_VERSION"
 		fi


### PR DESCRIPTION
This PR scans the latest releases and gets the most up to date release when a 2 digit version is specified.  To force the use of the original release, one can specify `.0`, for example `4.7.0`.  Also fetches the latest test suite.

Builds on https://github.com/wp-cli/scaffold-command/pull/34

Fixes #18