### PR TITLE
Removed incorrect pluralization rule for /([^aeiouy]|qu)ies$/ => $1y

### DIFF
--- a/src/Scaffold_Command.php
+++ b/src/Scaffold_Command.php
@@ -887,7 +887,6 @@ class Scaffold_Command extends WP_CLI_Command {
 			'/([m|l])ouse$/i'          => '\1ice',
 			'/(matr|vert|ind)ix|ex$/i' => '\1ices',
 			'/(x|ch|ss|sh)$/i'         => '\1es',
-			'/([^aeiouy]|qu)ies$/i'    => '\1y',
 			'/([^aeiouy]|qu)y$/i'      => '\1ies',
 			'/(hive)$/i'               => '\1s',
 			'/(?:([^f])fe|([lr])f)$/i' => '\1\2ves',


### PR DESCRIPTION
Removed incorrect pluralization rule for /([^aeiouy]|qu)ies$/ => $1y in Scaffold_Command.php file