### PR TITLE
Grunt i18n: unused var, ignored dirs

### DIFF
--- a/templates/plugin-gruntfile.mustache
+++ b/templates/plugin-gruntfile.mustache
@@ -15,7 +15,7 @@ module.exports = function( grunt ) {
 				options: {
 					updateDomains: true
 				},
-				src: [ '*.php', '**/*.php', '!\.git/**/*', '!bin/**/*', '!node_modules/**/*', '!tests/**/*', '!vendor/**/*' ]
+				src: [ '*.php', '**/*.php', '!\.git/**/*', '!bin/**/*', '!node_modules/**/*', '!tests/**/*' ]
 			}
 		},
 
@@ -31,7 +31,7 @@ module.exports = function( grunt ) {
 			target: {
 				options: {
 					domainPath: '/languages',
-					exclude: [ '\.git/*', 'bin/*', 'node_modules/*', 'tests/*', 'vendor/*' ],
+					exclude: [ '\.git/*', 'bin/*', 'node_modules/*', 'tests/*' ],
 					mainFile: '{{plugin_slug}}.php',
 					potFilename: '{{plugin_slug}}.pot',
 					potHeaders: {

--- a/templates/plugin-gruntfile.mustache
+++ b/templates/plugin-gruntfile.mustache
@@ -1,7 +1,7 @@
 module.exports = function( grunt ) {
 
 	'use strict';
-	var banner = '/**\n * <%= pkg.homepage %>\n * Copyright (c) <%= grunt.template.today("yyyy") %>\n * This file is generated automatically. Do not edit.\n */\n';
+
 	// Project configuration
 	grunt.initConfig( {
 
@@ -15,7 +15,7 @@ module.exports = function( grunt ) {
 				options: {
 					updateDomains: true
 				},
-				src: [ '*.php', '**/*.php', '!node_modules/**', '!php-tests/**', '!bin/**' ]
+				src: [ '*.php', '**/*.php', '!\.git/**/*', '!bin/**/*', '!node_modules/**/*', '!tests/**/*', '!vendor/**/*' ]
 			}
 		},
 
@@ -31,6 +31,7 @@ module.exports = function( grunt ) {
 			target: {
 				options: {
 					domainPath: '/languages',
+					exclude: [ '\.git/*', 'bin/*', 'node_modules/*', 'tests/*', 'vendor/*' ],
 					mainFile: '{{plugin_slug}}.php',
 					potFilename: '{{plugin_slug}}.pot',
 					potHeaders: {


### PR DESCRIPTION
* remove unused `banner` variable (`'banner' is assigned a value but never used.`)
* ignore `.git` dir
* reference correct tests dir (`php-tests` > `tests`)

Negating globbing patterns in `addtextdomain.update_all_domains` work but do not seem to have any effect on the makepot task (reproducible by putting a php file with a `__()` call in e.g. `bin` and running `grunt i18n --verbose`). Adding an `exclude` param to the `makepot` task seems to be the only way to have the dirs and files within them effectively ignored.
