### PR TITLE
Improve error message when running phpunit

### DIFF
--- a/templates/plugin-bootstrap.mustache
+++ b/templates/plugin-bootstrap.mustache
@@ -10,6 +10,10 @@ if ( ! $_tests_dir ) {
 	$_tests_dir = '/tmp/wordpress-tests-lib';
 }
 
+if ( ! file_exists( $_tests_dir . '/includes/functions.php' ) ) {
+	throw new Exception( "Could not find $_tests_dir/includes/functions.php, have you run bin/install-wp-tests.sh ?" );
+}
+
 // Give access to tests_add_filter() function.
 require_once $_tests_dir . '/includes/functions.php';
 

--- a/templates/theme-bootstrap.mustache
+++ b/templates/theme-bootstrap.mustache
@@ -10,6 +10,10 @@ if ( ! $_tests_dir ) {
 	$_tests_dir = '/tmp/wordpress-tests-lib';
 }
 
+if ( ! file_exists( $_tests_dir . '/includes/functions.php' ) ) {
+	throw new Exception( "Could not find $_tests_dir/includes/functions.php, have you run bin/install-wp-tests.sh ?" );
+}
+
 // Give access to tests_add_filter() function.
 require_once $_tests_dir . '/includes/functions.php';
 


### PR DESCRIPTION
This will help new users realise that they need to run install-wp-tests.sh before running the tests.
