### PR TITLE
CS: Show progress when invoking phpcs

### DIFF
--- a/templates/phpcs.xml.dist
+++ b/templates/phpcs.xml.dist
@@ -9,8 +9,8 @@
 	<arg name="extensions" value="php"/>
 	<file>.</file>
 
-	<!-- Show sniff codes in all reports -->
-	<arg value="s"/>
+	<!-- Show progress and sniff codes in all reports -->
+	<arg value="ps"/>
 
 	<exclude-pattern>*/node_modules/*</exclude-pattern>
 	<exclude-pattern>*/vendor/*</exclude-pattern>


### PR DESCRIPTION
Displays the progress meter to help identify that phpcs is working.

Closes #62.