### PR TITLE
get correct WP_TESTS_DIR on mcOS by default

### DIFF
--- a/templates/plugin-bootstrap.mustache
+++ b/templates/plugin-bootstrap.mustache
@@ -8,11 +8,7 @@
 $_tests_dir = getenv( 'WP_TESTS_DIR' );
 
 if ( ! $_tests_dir ) {
-	$_tmpdir = getenv( 'TMPDIR' );
-	if ( ! $_tmpdir ) {
-		$_tmpdir = '/tmp';
-	}
-	$_tests_dir = preg_replace( '#/$#', '', $_tmpdir ) . '/wordpress-tests-lib';
+	$_tests_dir = rtrim( sys_get_temp_dir(), '/\\' ) . '/wordpress-tests-lib';
 }
 
 if ( ! file_exists( $_tests_dir . '/includes/functions.php' ) ) {

--- a/templates/plugin-bootstrap.mustache
+++ b/templates/plugin-bootstrap.mustache
@@ -6,8 +6,13 @@
  */
 
 $_tests_dir = getenv( 'WP_TESTS_DIR' );
+
 if ( ! $_tests_dir ) {
-	$_tests_dir = '/tmp/wordpress-tests-lib';
+	$_tmpdir = getenv( 'TMPDIR' );
+	if ( ! $_tmpdir ) {
+		$_tmpdir = '/tmp';
+	}
+	$_tests_dir = preg_replace( '#/$#', '', $_tmpdir ) . '/wordpress-tests-lib';
 }
 
 if ( ! file_exists( $_tests_dir . '/includes/functions.php' ) ) {


### PR DESCRIPTION
The default value of `$TMPDIR` is not `/tmp` on macOS.

Related: https://github.com/wp-cli/scaffold-command/pull/61