### PR TITLE
Trim dashicon string

### DIFF
--- a/features/scaffold.feature
+++ b/features/scaffold.feature
@@ -173,6 +173,22 @@ Feature: WordPress code scaffolding
       'menu_icon'         => 'dashicons-art',
       """
 
+  Scenario: Scaffold a Custom Post Type with dashicon in the case of passing "dashicon-info"
+    Given a WP install
+    When I run `wp scaffold post-type zombie --dashicon="dashicon-info"`
+    Then STDOUT should contain:
+      """
+      'menu_icon'         => 'dashicons-info',
+      """
+
+  Scenario: Scaffold a Custom Post Type with dashicon in the case of passing "dashicons-info"
+    Given a WP install
+    When I run `wp scaffold post-type zombie --dashicon="dashicons-info"`
+    Then STDOUT should contain:
+      """
+      'menu_icon'         => 'dashicons-info',
+      """
+
   Scenario: Scaffold a plugin
     Given a WP install
     Given I run `wp plugin path`

--- a/src/Scaffold_Command.php
+++ b/src/Scaffold_Command.php
@@ -77,6 +77,10 @@ class Scaffold_Command extends WP_CLI_Command {
 			'dashicon'   => 'admin-post',
 		);
 
+		if ( $assoc_args['dashicon'] ) {
+			$assoc_args['dashicon'] = preg_replace( '/dashicon(-|s-)/', '', $assoc_args['dashicon'] );
+		}
+
 		$this->_scaffold( $args[0], $assoc_args, $defaults, '/post-types/', array(
 			'post_type.mustache',
 			'post_type_extended.mustache',

--- a/src/Scaffold_Command.php
+++ b/src/Scaffold_Command.php
@@ -77,10 +77,6 @@ class Scaffold_Command extends WP_CLI_Command {
 			'dashicon'   => 'admin-post',
 		);
 
-		if ( $assoc_args['dashicon'] ) {
-			$assoc_args['dashicon'] = preg_replace( '/dashicon(-|s-)/', '', $assoc_args['dashicon'] );
-		}
-
 		$this->_scaffold( $args[0], $assoc_args, $defaults, '/post-types/', array(
 			'post_type.mustache',
 			'post_type_extended.mustache',
@@ -153,6 +149,11 @@ class Scaffold_Command extends WP_CLI_Command {
 		) );
 
 		$vars = $this->extract_args( $assoc_args, $defaults );
+
+		$dashicon = \WP_CLI\Utils\get_flag_value( $assoc_args, 'dashicon' );
+		if ( $dashicon ) {
+			$vars['dashicon'] = preg_replace( '/dashicon(-|s-)/', '', $dashicon );
+		}
 
 		$vars['slug'] = $slug;
 


### PR DESCRIPTION
Related https://github.com/wp-cli/scaffold-command/issues/66

`--dashicon=dashicon-info`, `--dashicon=dashicons-info` and  `--dashicon=info`
will be `'menu_icon'         => 'dashicons-info'`.