### PR TITLE
Travis: allow Composer to determine PHPUnit version

### DIFF
--- a/templates/plugin-travis.mustache
+++ b/templates/plugin-travis.mustache
@@ -42,11 +42,7 @@ before_script:
   - |
     if [[ ! -z "$WP_VERSION" ]] ; then
       bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
-      if [[ ${TRAVIS_PHP_VERSION:0:2} == "5." ]]; then
-        composer global require "phpunit/phpunit=4.8.*"
-      else
-        composer global require "phpunit/phpunit=5.7.*"
-      fi
+      composer global require "phpunit/phpunit=4.8.*|5.7.*"
     fi
   - |
     if [[ "$WP_TRAVISCI" == "phpcs" ]] ; then


### PR DESCRIPTION
Allows installation of PHPUnit 5.7 instead of 4.8 when running PHP 5.6. Closes #74.