### PR TITLE
Use wp_cli_test/password1 instead of root/no-password in install-wp-tests.feature.

### DIFF
--- a/bin/install-package-tests.sh
+++ b/bin/install-package-tests.sh
@@ -5,6 +5,7 @@ set -ex
 install_db() {
 	mysql -e 'CREATE DATABASE IF NOT EXISTS wp_cli_test;' -uroot
 	mysql -e 'GRANT ALL PRIVILEGES ON wp_cli_test.* TO "wp_cli_test"@"localhost" IDENTIFIED BY "password1"' -uroot
+	mysql -e 'GRANT ALL PRIVILEGES ON wp_cli_test_scaffold.* TO "wp_cli_test"@"localhost" IDENTIFIED BY "password1"' -uroot
 }
 
 install_db

--- a/features/install-wp-tests.feature
+++ b/features/install-wp-tests.feature
@@ -1,3 +1,4 @@
+# Note: You need to execute the mysql command `GRANT ALL PRIVILEGES ON wp_cli_test_scaffold.* TO "wp_cli_test"@"localhost" IDENTIFIED BY "password1";` for these tests to work locally.
 Feature: Scaffold install-wp-tests.sh tests
 
   Scenario: Help should be displayed
@@ -18,11 +19,11 @@ Feature: Scaffold install-wp-tests.sh tests
     And I run `wp plugin path`
     And save STDOUT as {PLUGIN_DIR}
     And I run `wp scaffold plugin hello-world`
-    And I run `echo "DROP DATABASE IF EXISTS wordpress_behat_test" | mysql -u root`
+    And I run `echo "DROP DATABASE IF EXISTS wp_cli_test_scaffold" | mysql -u wp_cli_test -ppassword1`
     And I try `rm -fr /tmp/behat-wordpress-tests-lib`
     And I try `rm -fr /tmp/behat-wordpress`
 
-    When I run `WP_TESTS_DIR=/tmp/behat-wordpress-tests-lib WP_CORE_DIR=/tmp/behat-wordpress /usr/bin/env bash {PLUGIN_DIR}/hello-world/bin/install-wp-tests.sh wordpress_behat_test root '' localhost latest`
+    When I run `WP_TESTS_DIR=/tmp/behat-wordpress-tests-lib WP_CORE_DIR=/tmp/behat-wordpress /usr/bin/env bash {PLUGIN_DIR}/hello-world/bin/install-wp-tests.sh wp_cli_test_scaffold wp_cli_test password1 localhost latest`
     Then the return code should be 0
     And the /tmp/behat-wordpress-tests-lib directory should contain:
       """
@@ -60,11 +61,11 @@ Feature: Scaffold install-wp-tests.sh tests
       """
     And the {PLUGIN_DIR}/hello-world/phpunit.xml.dist file should exist
 
-    When I run `echo 'show databases' | mysql -u root`
+    When I run `echo 'show databases' | mysql -u wp_cli_test -ppassword1`
     Then the return code should be 0
     And STDOUT should contain:
       """
-      wordpress_behat_test
+      wp_cli_test_scaffold
       """
 
     When I run `WP_TESTS_DIR=/tmp/behat-wordpress-tests-lib phpunit -c {PLUGIN_DIR}/hello-world/phpunit.xml.dist`
@@ -75,11 +76,11 @@ Feature: Scaffold install-wp-tests.sh tests
     And I run `wp plugin path`
     And save STDOUT as {PLUGIN_DIR}
     And I run `wp scaffold plugin hello-world`
-    And I run `echo "DROP DATABASE IF EXISTS wordpress_behat_test" | mysql -u root`
+    And I run `echo "DROP DATABASE IF EXISTS wp_cli_test_scaffold" | mysql -u wp_cli_test -ppassword1`
     And I try `rm -fr /tmp/behat-wordpress-tests-lib`
     And I try `rm -fr /tmp/behat-wordpress`
 
-    When I run `WP_TESTS_DIR=/tmp/behat-wordpress-tests-lib WP_CORE_DIR=/tmp/behat-wordpress /usr/bin/env bash {PLUGIN_DIR}/hello-world/bin/install-wp-tests.sh wordpress_behat_test root '' localhost trunk`
+    When I run `WP_TESTS_DIR=/tmp/behat-wordpress-tests-lib WP_CORE_DIR=/tmp/behat-wordpress /usr/bin/env bash {PLUGIN_DIR}/hello-world/bin/install-wp-tests.sh wp_cli_test_scaffold wp_cli_test password1 localhost trunk`
     Then the return code should be 0
     And the /tmp/behat-wordpress-tests-lib directory should contain:
       """
@@ -118,11 +119,11 @@ Feature: Scaffold install-wp-tests.sh tests
     And the contents of the /tmp/behat-wordpress/wp-includes/version.php file should match /\-(alpha|beta[0-9]+)\-/
     And the {PLUGIN_DIR}/hello-world/phpunit.xml.dist file should exist
 
-    When I run `echo 'show databases' | mysql -u root`
+    When I run `echo 'show databases' | mysql -u wp_cli_test -ppassword1`
     Then the return code should be 0
     And STDOUT should contain:
       """
-      wordpress_behat_test
+      wp_cli_test_scaffold
       """
 
     When I run `WP_TESTS_DIR=/tmp/behat-wordpress-tests-lib phpunit -c {PLUGIN_DIR}/hello-world/phpunit.xml.dist`
@@ -133,11 +134,11 @@ Feature: Scaffold install-wp-tests.sh tests
     And I run `wp plugin path`
     And save STDOUT as {PLUGIN_DIR}
     And I run `wp scaffold plugin hello-world`
-    And I run `echo "DROP DATABASE IF EXISTS wordpress_behat_test" | mysql -u root`
+    And I run `echo "DROP DATABASE IF EXISTS wp_cli_test_scaffold" | mysql -u wp_cli_test -ppassword1`
     And I try `rm -fr /tmp/behat-wordpress-tests-lib`
     And I try `rm -fr /tmp/behat-wordpress`
 
-    When I run `WP_TESTS_DIR=/tmp/behat-wordpress-tests-lib WP_CORE_DIR=/tmp/behat-wordpress /usr/bin/env bash {PLUGIN_DIR}/hello-world/bin/install-wp-tests.sh wordpress_behat_test root '' localhost 3.7`
+    When I run `WP_TESTS_DIR=/tmp/behat-wordpress-tests-lib WP_CORE_DIR=/tmp/behat-wordpress /usr/bin/env bash {PLUGIN_DIR}/hello-world/bin/install-wp-tests.sh wp_cli_test_scaffold wp_cli_test password1 localhost 3.7`
     Then the return code should be 0
     And the /tmp/behat-wordpress-tests-lib directory should contain:
       """
@@ -178,9 +179,9 @@ Feature: Scaffold install-wp-tests.sh tests
       3.7
       """
 
-    When I run `echo 'show databases' | mysql -u root`
+    When I run `echo 'show databases' | mysql -u wp_cli_test -ppassword1`
     Then the return code should be 0
     And STDOUT should contain:
       """
-      wordpress_behat_test
+      wp_cli_test_scaffold
       """


### PR DESCRIPTION
Closes https://github.com/wp-cli/scaffold-command/issues/80

Uses `wp_cli_test/password1` instead of `root/<no-password>` in a number of tests in `features/install-wp-tests.feature` to make it more convenient to run these tests locally. Also renames the test db to `wp_cli_test_scaffold` from `wordpress_behat_test`, to match up more with `wp_cli_test` I guess.

Requires the test user to run the mysql command
```
GRANT ALL PRIVILEGES ON wp_cli_test_scaffold.* TO "wp_cli_test"@"localhost" IDENTIFIED BY "password1";
```