### PR TITLE
Add a default task to scaffolded `Gruntfile.js`

### DIFF
--- a/templates/plugin-gruntfile.mustache
+++ b/templates/plugin-gruntfile.mustache
@@ -47,6 +47,7 @@ module.exports = function( grunt ) {
 
 	grunt.loadNpmTasks( 'grunt-wp-i18n' );
 	grunt.loadNpmTasks( 'grunt-wp-readme-to-markdown' );
+	grunt.registerTask( 'default', [ 'i18n','readme' ] );
 	grunt.registerTask( 'i18n', ['addtextdomain', 'makepot'] );
 	grunt.registerTask( 'readme', ['wp_readme_to_markdown'] );
 


### PR DESCRIPTION
The default task makes running `grunt` useful, instead of producing an
error.