### PR TITLE
Block: Update PHP template to use the server script and style api

### DIFF
--- a/features/scaffold-block.feature
+++ b/features/scaffold-block.feature
@@ -36,7 +36,7 @@ Feature: WordPress block code scaffolding
     Then the {PLUGIN_DIR}/blocks/the-green-mile.php file should exist
     And the {PLUGIN_DIR}/blocks/the-green-mile.php file should contain:
       """
-      function the_green_mile_enqueue_block_editor_assets() {
+      function the_green_mile_block_init() {
       """
     And the {PLUGIN_DIR}/blocks/the-green-mile.php file should contain:
       """
@@ -48,15 +48,15 @@ Feature: WordPress block code scaffolding
       """
     And the {PLUGIN_DIR}/blocks/the-green-mile.php file should contain:
       """
-	    add_action( 'enqueue_block_editor_assets', 'the_green_mile_enqueue_block_editor_assets' );
-      """
-    And the {PLUGIN_DIR}/blocks/the-green-mile.php file should contain:
-      """
 	    $style_css = 'the-green-mile/style.css';
       """
     And the {PLUGIN_DIR}/blocks/the-green-mile.php file should contain:
       """
-	    add_action( 'enqueue_block_assets', 'the_green_mile_enqueue_block_assets' );
+	    register_block_type( 'movies/the-green-mile', array(
+      """
+    And the {PLUGIN_DIR}/blocks/the-green-mile.php file should contain:
+      """
+	    add_action( 'init', 'the_green_mile_block_init' );
       """
     And the {PLUGIN_DIR}/blocks/the-green-mile/block.js file should exist
     And the {PLUGIN_DIR}/blocks/the-green-mile/block.js file should contain:

--- a/templates/block-php.mustache
+++ b/templates/block-php.mustache
@@ -6,13 +6,15 @@
  */
 
 /**
- * Enqueues block assets to apply inside the editor only.
+ * Registers all block assets so that they can be enqueued through Gutenberg in the corresponding context.
+ *
+ * @see https://wordpress.org/gutenberg/handbook/blocks/writing-your-first-block-type/#enqueuing-block-scripts
  */
-function {{machine_name}}_enqueue_block_editor_assets() {
+function {{machine_name}}_block_init() {
 	$dir = dirname( __FILE__ );
 
 	$block_js = '{{slug}}/block.js';
-	wp_enqueue_script(
+	wp_register_script(
 		'{{slug}}-block-editor',
 		plugins_url( $block_js, __FILE__ ),
 		array(
@@ -24,7 +26,7 @@ function {{machine_name}}_enqueue_block_editor_assets() {
 	);
 
 	$editor_css = '{{slug}}/editor.css';
-	wp_enqueue_style(
+	wp_register_style(
 		'{{slug}}-block-editor',
 		plugins_url( $editor_css, __FILE__ ),
 		array(
@@ -32,23 +34,21 @@ function {{machine_name}}_enqueue_block_editor_assets() {
 		),
 		filemtime( "$dir/$editor_css" )
 	);
-}
-add_action( 'enqueue_block_editor_assets', '{{machine_name}}_enqueue_block_editor_assets' );
-
-/**
- * Enqueues block assets to apply both on the front of your site and in the editor.
- */
-function {{machine_name}}_enqueue_block_assets() {
-	$dir = dirname( __FILE__ );
 
 	$style_css = '{{slug}}/style.css';
-	wp_enqueue_style(
-        '{{slug}}-block',
+	wp_register_style(
+		'{{slug}}-block',
 		plugins_url( $style_css, __FILE__ ),
 		array(
-            'wp-blocks',
+			'wp-blocks',
 		),
 		filemtime( "$dir/$style_css" )
 	);
+
+	register_block_type( '{{namespace}}/{{slug}}', array(
+		'editor_script' => '{{slug}}-block-editor',
+		'editor_style'  => '{{slug}}-block-editor',
+		'style'         => '{{slug}}-block',
+	) );
 }
-add_action( 'enqueue_block_assets', '{{machine_name}}_enqueue_block_assets' );
+add_action( 'init', '{{machine_name}}_block_init' );

--- a/templates/block-php.mustache
+++ b/templates/block-php.mustache
@@ -1,12 +1,14 @@
 <?php
 /**
- * Functions to register client-side assets (scripts and stylesheets) for the Gutenberg block.
+ * Functions to register client-side assets (scripts and stylesheets) for the
+ * Gutenberg block.
  *
  * @package {{namespace}}
  */
 
 /**
- * Registers all block assets so that they can be enqueued through Gutenberg in the corresponding context.
+ * Registers all block assets so that they can be enqueued through Gutenberg in
+ * the corresponding context.
  *
  * @see https://wordpress.org/gutenberg/handbook/blocks/writing-your-first-block-type/#enqueuing-block-scripts
  */


### PR DESCRIPTION
This PR updates PHP template generated with `wp scaffold block` command. It adds changes introduced by @aduth in https://github.com/WordPress/gutenberg/pull/4039. Both ways are still supported, but the new one is the preferred one.

Generated output after changes introduced:

```php
<?php
/**
 * Functions to register client-side assets (scripts and stylesheets) for the Gutenberg block.
 *
 * @package books
 */

/**
 * Enqueues all block assets to apply both on the front of your site and in the editor.
 *
 * @see https://wordpress.org/gutenberg/handbook/blocks/writing-your-first-block-type/#enqueuing-block-scripts
 */
function my_book_block_init() {
	$dir = dirname( __FILE__ );

	$block_js = 'my-book/block.js';
	wp_register_script(
		'my-book-block-editor',
		plugins_url( $block_js, __FILE__ ),
		array(
			'wp-blocks',
			'wp-i18n',
			'wp-element',
		),
		filemtime( "$dir/$block_js" )
	);

	$editor_css = 'my-book/editor.css';
	wp_register_style(
		'my-book-block-editor',
		plugins_url( $editor_css, __FILE__ ),
		array(
			'wp-blocks',
		),
		filemtime( "$dir/$editor_css" )
	);

	$style_css = 'my-book/style.css';
	wp_register_style(
		'my-book-block',
		plugins_url( $style_css, __FILE__ ),
		array(
			'wp-blocks',
		),
		filemtime( "$dir/$style_css" )
	);

	register_block_type( 'books/my-book', array(
		'editor_script' => 'my-book-block-editor',
		'editor_style'  => 'my-book-block-editor',
		'style'         => 'my-book-block',
	) );
}
add_action( 'init', 'my_book_block_init' );
```