### PR TITLE
[WIP] Switch CircleCI template to CircleCI 2.0.

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -5,7 +5,7 @@
 .editorconfig
 .travis.yml
 behat.yml
-circle.yml
+.circleci/config.yml
 bin/
 features/
 utils/

--- a/features/scaffold-plugin-tests.feature
+++ b/features/scaffold-plugin-tests.feature
@@ -38,6 +38,7 @@ Feature: Scaffold plugin unit tests
     And the {PLUGIN_DIR}/hello-world/phpunit.xml.dist file should exist
     And the {PLUGIN_DIR}/hello-world/phpcs.xml.dist file should exist
     And the {PLUGIN_DIR}/hello-world/circle.yml file should not exist
+    And the {PLUGIN_DIR}/hello-world/.circleci directory should not exist
     And the {PLUGIN_DIR}/hello-world/.gitlab-ci.yml file should not exist
     And the {PLUGIN_DIR}/hello-world/.travis.yml file should contain:
       """
@@ -61,7 +62,7 @@ Feature: Scaffold plugin unit tests
           - php: 7.0
             env: WP_VERSION=latest
           - php: 5.6
-            env: WP_VERSION=4.4
+            env: WP_VERSION=4.5
           - php: 5.6
             env: WP_VERSION=latest
           - php: 5.6
@@ -85,9 +86,22 @@ Feature: Scaffold plugin unit tests
     When I run `wp plugin path hello-world --dir`
     Then save STDOUT as {PLUGIN_DIR}
     And the {PLUGIN_DIR}/.travis.yml file should not exist
-    And the {PLUGIN_DIR}/circle.yml file should contain:
+    And the {PLUGIN_DIR}/circle.yml file should not exist
+    And the {PLUGIN_DIR}/.circleci/config.yml file should contain:
       """
-      version: 5.6.22
+      version: 2
+      """
+    And the {PLUGIN_DIR}/.circleci/config.yml file should contain:
+      """
+      php56-build
+      """
+    And the {PLUGIN_DIR}/.circleci/config.yml file should contain:
+      """
+      php70-build
+      """
+    And the {PLUGIN_DIR}/.circleci/config.yml file should contain:
+      """
+      php71-build
       """
 
   Scenario: Scaffold plugin tests with Circle as the provider, part two
@@ -100,27 +114,28 @@ Feature: Scaffold plugin unit tests
     When I run `wp scaffold plugin-tests hello-world --ci=circle`
     Then STDOUT should not be empty
     And the {PLUGIN_DIR}/.travis.yml file should not exist
-    And the {PLUGIN_DIR}/circle.yml file should contain:
+    And the {PLUGIN_DIR}/circle.yml file should not exist
+    And the {PLUGIN_DIR}/.circleci/config.yml file should contain:
       """
-      version: 5.6.22
+      version: 2
       """
-    And the {PLUGIN_DIR}/circle.yml file should contain:
+    And the {PLUGIN_DIR}/.circleci/config.yml file should contain:
       """
-          - |
-            rm -rf $WP_TESTS_DIR $WP_CORE_DIR
-            bash bin/install-wp-tests.sh wordpress_test ubuntu '' 127.0.0.1 4.4
-            phpunit
-            WP_MULTISITE=1 phpunit
-          - |
-            rm -rf $WP_TESTS_DIR $WP_CORE_DIR
-            bash bin/install-wp-tests.sh wordpress_test ubuntu '' 127.0.0.1 latest
-            phpunit
-            WP_MULTISITE=1 phpunit
-          - |
-            rm -rf $WP_TESTS_DIR $WP_CORE_DIR
-            bash bin/install-wp-tests.sh wordpress_test ubuntu '' 127.0.0.1 trunk
-            phpunit
-            WP_MULTISITE=1 phpunit
+                  rm -rf $WP_TESTS_DIR $WP_CORE_DIR
+                  bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 4.5 $SKIP_DB_CREATE
+                  phpunit
+                  WP_MULTISITE=1 phpunit
+                  SKIP_DB_CREATE=true
+                  rm -rf $WP_TESTS_DIR $WP_CORE_DIR
+                  bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest $SKIP_DB_CREATE
+                  phpunit
+                  WP_MULTISITE=1 phpunit
+                  SKIP_DB_CREATE=true
+                  rm -rf $WP_TESTS_DIR $WP_CORE_DIR
+                  bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 trunk $SKIP_DB_CREATE
+                  phpunit
+                  WP_MULTISITE=1 phpunit
+                  SKIP_DB_CREATE=true
       """
 
   Scenario: Scaffold plugin tests with Gitlab as the provider

--- a/features/scaffold-theme-tests.feature
+++ b/features/scaffold-theme-tests.feature
@@ -35,6 +35,7 @@ Feature: Scaffold theme unit tests
     And the {THEME_DIR}/p2child/phpunit.xml.dist file should exist
     And the {THEME_DIR}/p2child/phpcs.xml.dist file should exist
     And the {THEME_DIR}/p2child/circle.yml file should not exist
+    And the {THEME_DIR}/p2child/.circleci directory should not exist
     And the {THEME_DIR}/p2child/.gitlab-ci.yml file should not exist
     And the {THEME_DIR}/p2child/.travis.yml file should contain:
       """
@@ -124,9 +125,22 @@ Feature: Scaffold theme unit tests
     When I run `wp scaffold theme-tests p2child --ci=circle`
     Then STDOUT should not be empty
     And the {THEME_DIR}/p2child/.travis.yml file should not exist
-    And the {THEME_DIR}/p2child/circle.yml file should contain:
+    And the {THEME_DIR}/p2child/circle.yml file should not exist
+    And the {THEME_DIR}/p2child/.circleci/config.yml file should contain:
       """
-      version: 5.6.22
+      version: 2
+      """
+    And the {THEME_DIR}/p2child/.circleci/config.yml file should contain:
+      """
+      php56-build
+      """
+    And the {THEME_DIR}/p2child/.circleci/config.yml file should contain:
+      """
+      php70-build
+      """
+    And the {THEME_DIR}/p2child/.circleci/config.yml file should contain:
+      """
+      php71-build
       """
 
   Scenario: Scaffold theme tests with Gitlab as the provider

--- a/features/scaffold.feature
+++ b/features/scaffold.feature
@@ -452,7 +452,7 @@ Feature: WordPress code scaffolding
           - php: 7.0
             env: WP_VERSION=latest
           - php: 5.6
-            env: WP_VERSION=4.4
+            env: WP_VERSION=4.5
           - php: 5.6
             env: WP_VERSION=latest
           - php: 5.6

--- a/src/Scaffold_Command.php
+++ b/src/Scaffold_Command.php
@@ -865,7 +865,7 @@ class Scaffold_Command extends WP_CLI_Command {
 		if ( 'travis' === $assoc_args['ci'] ) {
 			$files_to_create["{$target_dir}/.travis.yml"] = self::mustache_render( 'plugin-travis.mustache', compact( 'wp_versions_to_test' ) );
 		} else if ( 'circle' === $assoc_args['ci'] ) {
-			$files_to_create["{$target_dir}/circle.yml"] = self::mustache_render( 'plugin-circle.mustache', compact( 'wp_versions_to_test' ) );
+			$files_to_create["{$target_dir}/.circleci/config.yml"] = self::mustache_render( 'plugin-circle.mustache', compact( 'wp_versions_to_test' ) );
 		} else if ( 'gitlab' === $assoc_args['ci'] ) {
 			$files_to_create["{$target_dir}/.gitlab-ci.yml"] = self::mustache_render( 'plugin-gitlab.mustache' );
 		}

--- a/templates/plugin-circle.mustache
+++ b/templates/plugin-circle.mustache
@@ -24,7 +24,11 @@ jobs:
             source /home/circleci/.bashrc
       - run:
           name: "Install Dependencies"
-          command: sudo apt-get update && sudo apt-get install subversion
+          command: |
+            sudo apt-get update && sudo apt-get install subversion
+            sudo docker-php-ext-install mysqli
+            sudo sh -c "printf '\ndeb http://ftp.us.debian.org/debian sid main\n' >> /etc/apt/sources.list"
+            sudo apt-get update && sudo apt-get install mysql-client-5.7
       - run:
           name: "Run Tests"
           command: |
@@ -32,11 +36,13 @@ jobs:
             composer global require wp-coding-standards/wpcs
             phpcs --config-set installed_paths $HOME/.composer/vendor/wp-coding-standards/wpcs
             phpcs
+            SKIP_DB_CREATE=false
             {{#wp_versions_to_test}}
             rm -rf $WP_TESTS_DIR $WP_CORE_DIR
-            bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 {{.}}
+            bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 {{.}} $SKIP_DB_CREATE
             phpunit
             WP_MULTISITE=1 phpunit
+            SKIP_DB_CREATE=true
             {{/wp_versions_to_test}}
 
   php70-build:
@@ -55,7 +61,11 @@ jobs:
             source /home/circleci/.bashrc
       - run:
           name: "Install Dependencies"
-          command: sudo apt-get update && sudo apt-get install subversion
+          command: |
+            sudo apt-get update && sudo apt-get install subversion
+            sudo docker-php-ext-install mysqli
+            sudo sh -c "printf '\ndeb http://ftp.us.debian.org/debian sid main\n' >> /etc/apt/sources.list"
+            sudo apt-get update && sudo apt-get install mysql-client-5.7
       - run:
           name: "Run Tests"
           command: |
@@ -84,7 +94,11 @@ jobs:
             source /home/circleci/.bashrc
       - run:
           name: "Install Dependencies"
-          command: sudo apt-get update && sudo apt-get install subversion
+          command: |
+            sudo apt-get update && sudo apt-get install subversion
+            sudo docker-php-ext-install mysqli
+            sudo sh -c "printf '\ndeb http://ftp.us.debian.org/debian sid main\n' >> /etc/apt/sources.list"
+            sudo apt-get update && sudo apt-get install mysql-client-5.7
       - run:
           name: "Run Tests"
           command: |

--- a/templates/plugin-circle.mustache
+++ b/templates/plugin-circle.mustache
@@ -24,7 +24,7 @@ jobs:
             source /home/circleci/.bashrc
       - run:
           name: "Install Dependencies"
-          command: apt-get update && apt-get install subversion
+          command: sudo apt-get update && sudo apt-get install subversion
       - run:
           name: "Run Tests"
           command: |
@@ -34,7 +34,7 @@ jobs:
             phpcs
             {{#wp_versions_to_test}}
             rm -rf $WP_TESTS_DIR $WP_CORE_DIR
-            bash bin/install-wp-tests.sh wordpress_test ubuntu '' 127.0.0.1 {{.}}
+            bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 {{.}}
             phpunit
             WP_MULTISITE=1 phpunit
             {{/wp_versions_to_test}}
@@ -55,7 +55,7 @@ jobs:
             source /home/circleci/.bashrc
       - run:
           name: "Install Dependencies"
-          command: apt-get update && apt-get install subversion
+          command: sudo apt-get update && sudo apt-get install subversion
       - run:
           name: "Run Tests"
           command: |
@@ -64,7 +64,7 @@ jobs:
             phpcs --config-set installed_paths $HOME/.composer/vendor/wp-coding-standards/wpcs
             phpcs
             rm -rf $WP_TESTS_DIR $WP_CORE_DIR
-            bash bin/install-wp-tests.sh wordpress_test ubuntu '' 127.0.0.1 latest
+            bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest
             phpunit
             WP_MULTISITE=1 phpunit
 
@@ -84,7 +84,7 @@ jobs:
             source /home/circleci/.bashrc
       - run:
           name: "Install Dependencies"
-          command: apt-get update && apt-get install subversion
+          command: sudo apt-get update && sudo apt-get install subversion
       - run:
           name: "Run Tests"
           command: |
@@ -93,6 +93,6 @@ jobs:
             phpcs --config-set installed_paths $HOME/.composer/vendor/wp-coding-standards/wpcs
             phpcs
             rm -rf $WP_TESTS_DIR $WP_CORE_DIR
-            bash bin/install-wp-tests.sh wordpress_test ubuntu '' 127.0.0.1 latest
+            bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest
             phpunit
             WP_MULTISITE=1 phpunit

--- a/templates/plugin-circle.mustache
+++ b/templates/plugin-circle.mustache
@@ -1,39 +1,98 @@
-machine:
-  php:
-    version: 5.6.22
-  environment:
-    WP_TESTS_DIR: /tmp/wordpress-tests-lib
-    WP_CORE_DIR: /tmp/wordpress/
-    PATH: $HOME/.composer/vendor/bin:$PATH
+workflows:
+  version: 2
+  main:
+    jobs:
+      - php56-build
+      - php70-build
+      - php71-build
 
-dependencies:
-  pre:
-    - sudo apt-get update; sudo apt-get install subversion
+version: 2
+jobs:
+  php56-build:
+    docker:
+      - image: circleci/php:5.6
+      - image: circleci/mysql:5.7
+    environment:
+      - WP_TESTS_DIR: "/tmp/wordpress-tests-lib"
+      - WP_CORE_DIR: "/tmp/wordpress/"
+    steps:
+      - checkout
+      - run:
+          name: "Setup Environment Variables"
+          command: |
+            echo "export PATH=$HOME/.composer/vendor/bin:$PATH" >> $BASH_ENV
+            source /home/circleci/.bashrc
+      - run:
+          name: "Install Dependencies"
+          command: apt-get update && apt-get install subversion
+      - run:
+          name: "Run Tests"
+          command: |
+            composer global require "phpunit/phpunit=5.7.*"
+            composer global require wp-coding-standards/wpcs
+            phpcs --config-set installed_paths $HOME/.composer/vendor/wp-coding-standards/wpcs
+            phpcs
+            {{#wp_versions_to_test}}
+            rm -rf $WP_TESTS_DIR $WP_CORE_DIR
+            bash bin/install-wp-tests.sh wordpress_test ubuntu '' 127.0.0.1 {{.}}
+            phpunit
+            WP_MULTISITE=1 phpunit
+            {{/wp_versions_to_test}}
 
-test:
-  pre:
-    - composer global require "phpunit/phpunit=5.7.*"
-    - |
-      composer global require wp-coding-standards/wpcs
-      phpcs --config-set installed_paths $HOME/.composer/vendor/wp-coding-standards/wpcs
-  override:
-    - phpcs
-    {{#wp_versions_to_test}}
-    - |
-      rm -rf $WP_TESTS_DIR $WP_CORE_DIR
-      bash bin/install-wp-tests.sh wordpress_test ubuntu '' 127.0.0.1 {{.}}
-      phpunit
-      WP_MULTISITE=1 phpunit
-    {{/wp_versions_to_test}}
-    - |
-      phpenv global 7.0.17
-      rm -rf $WP_TESTS_DIR $WP_CORE_DIR
-      bash bin/install-wp-tests.sh wordpress_test ubuntu '' 127.0.0.1 latest
-      phpunit
-      WP_MULTISITE=1 phpunit
-    - |
-      phpenv global 7.1.3
-      rm -rf $WP_TESTS_DIR $WP_CORE_DIR
-      bash bin/install-wp-tests.sh wordpress_test ubuntu '' 127.0.0.1 latest
-      phpunit
-      WP_MULTISITE=1 phpunit
+  php70-build:
+    docker:
+      - image: circleci/php:7.0
+      - image: circleci/mysql:5.7
+    environment:
+      - WP_TESTS_DIR: "/tmp/wordpress-tests-lib"
+      - WP_CORE_DIR: "/tmp/wordpress/"
+    steps:
+      - checkout
+      - run:
+          name: "Setup Environment Variables"
+          command: |
+            echo "export PATH=$HOME/.composer/vendor/bin:$PATH" >> $BASH_ENV
+            source /home/circleci/.bashrc
+      - run:
+          name: "Install Dependencies"
+          command: apt-get update && apt-get install subversion
+      - run:
+          name: "Run Tests"
+          command: |
+            composer global require "phpunit/phpunit=5.7.*"
+            composer global require wp-coding-standards/wpcs
+            phpcs --config-set installed_paths $HOME/.composer/vendor/wp-coding-standards/wpcs
+            phpcs
+            rm -rf $WP_TESTS_DIR $WP_CORE_DIR
+            bash bin/install-wp-tests.sh wordpress_test ubuntu '' 127.0.0.1 latest
+            phpunit
+            WP_MULTISITE=1 phpunit
+
+  php71-build:
+    docker:
+      - image: circleci/php:7.1
+      - image: circleci/mysql:5.7
+    environment:
+      - WP_TESTS_DIR: "/tmp/wordpress-tests-lib"
+      - WP_CORE_DIR: "/tmp/wordpress/"
+    steps:
+      - checkout
+      - run:
+          name: "Setup Environment Variables"
+          command: |
+            echo "export PATH=$HOME/.composer/vendor/bin:$PATH" >> $BASH_ENV
+            source /home/circleci/.bashrc
+      - run:
+          name: "Install Dependencies"
+          command: apt-get update && apt-get install subversion
+      - run:
+          name: "Run Tests"
+          command: |
+            composer global require "phpunit/phpunit=5.7.*"
+            composer global require wp-coding-standards/wpcs
+            phpcs --config-set installed_paths $HOME/.composer/vendor/wp-coding-standards/wpcs
+            phpcs
+            rm -rf $WP_TESTS_DIR $WP_CORE_DIR
+            bash bin/install-wp-tests.sh wordpress_test ubuntu '' 127.0.0.1 latest
+            phpunit
+            WP_MULTISITE=1 phpunit

--- a/templates/plugin-distignore.mustache
+++ b/templates/plugin-distignore.mustache
@@ -9,7 +9,7 @@
 Thumbs.db
 behat.yml
 bin
-circle.yml
+.circleci/config.yml
 composer.json
 composer.lock
 Gruntfile.js

--- a/templates/plugin-readme.mustache
+++ b/templates/plugin-readme.mustache
@@ -2,7 +2,7 @@
 Contributors: (this should be a list of wordpress.org userid's)
 Donate link: https://example.com/
 Tags: comments, spam
-Requires at least: 4.4
+Requires at least: 4.5
 Tested up to: {{plugin_tested_up_to}}
 Stable tag: 0.1.0
 License: GPLv2 or later


### PR DESCRIPTION
Fixes #52.

This is a first draft at converting the CircleCI template from using CircleCI 1.0 to 2.0

Notes:

1. I haven't looked into optimizing the config yet. Just trying to do a basic conversion.
2. The PHP Docker images are locked to PHP vX.Y, not a specific bug release. We can change that if the project owners decide they specifically want a full vX.Y.Z.
3. I don't know Mustache well so this config may not be proper syntax for Mustache.
4. I haven't run this config nor tested it yet. I plan to soon but others can join in as well. ;)
5. The new config file should be located at ./.circleci/config.yml instead of ./circle.yml. How would I get that to work here?