### PR TITLE
Filter theme_root in tests/bootstrap.php.

### DIFF
--- a/features/scaffold-theme-tests.feature
+++ b/features/scaffold-theme-tests.feature
@@ -78,8 +78,13 @@ Feature: Scaffold theme unit tests
       """
       <?php echo __FILE__ . " loaded.\n";
       """
+    And I run `MYSQL_PWD=password1 mysql -u wp_cli_test -e "DROP DATABASE IF EXISTS wp_cli_test_scaffold"`
+    And I try `rm -fr /tmp/behat-wordpress-tests-lib`
+    And I try `rm -fr /tmp/behat-wordpress`
+	And I try `WP_TESTS_DIR=/tmp/behat-wordpress-tests-lib WP_CORE_DIR=/tmp/behat-wordpress {THEME_DIR}/p2child/bin/install-wp-tests.sh wp_cli_test_scaffold wp_cli_test password1 localhost latest`
+    Then the return code should be 0
 
-    When I run `cd {THEME_DIR}/p2child; phpunit`
+    When I run `cd {THEME_DIR}/p2child; WP_TESTS_DIR=/tmp/behat-wordpress-tests-lib phpunit`
     Then STDOUT should contain:
       """
       p2child/functions.php loaded.
@@ -93,7 +98,7 @@ Feature: Scaffold theme unit tests
       OK (1 test, 1 assertion)
       """
 
-    When I run `cd {THEME_DIR}/p2child; WP_MULTISITE=1 phpunit`
+    When I run `cd {THEME_DIR}/p2child; WP_MULTISITE=1 WP_TESTS_DIR=/tmp/behat-wordpress-tests-lib phpunit`
     Then STDOUT should contain:
       """
       p2child/functions.php loaded.

--- a/features/scaffold-theme-tests.feature
+++ b/features/scaffold-theme-tests.feature
@@ -18,7 +18,7 @@ Feature: Scaffold theme unit tests
       """
     And the {THEME_DIR}/p2child/tests/bootstrap.php file should contain:
       """
-      register_theme_directory( dirname( $theme_dir ) );
+      register_theme_directory( $theme_root );
       """
     And the {THEME_DIR}/p2child/tests/bootstrap.php file should contain:
       """
@@ -71,6 +71,40 @@ Feature: Scaffold theme unit tests
     Then STDOUT should be:
       """
       executable
+      """
+
+    # Warning: overwriting generated functions.php file, so functions.php file loaded only tests beyond here...
+    Given a wp-content/themes/p2child/functions.php file:
+      """
+      <?php echo __FILE__ . " loaded.\n";
+      """
+
+    When I run `cd {THEME_DIR}/p2child; phpunit`
+    Then STDOUT should contain:
+      """
+      p2child/functions.php loaded.
+      """
+    And STDOUT should contain:
+      """
+      Running as single site
+      """
+    And STDOUT should contain:
+      """
+      OK (1 test, 1 assertion)
+      """
+
+    When I run `cd {THEME_DIR}/p2child; WP_MULTISITE=1 phpunit`
+    Then STDOUT should contain:
+      """
+      p2child/functions.php loaded.
+      """
+    And STDOUT should contain:
+      """
+      Running as multisite
+      """
+    And STDOUT should contain:
+      """
+      OK (1 test, 1 assertion)
       """
 
   Scenario: Scaffold theme tests invalid theme

--- a/templates/theme-bootstrap.mustache
+++ b/templates/theme-bootstrap.mustache
@@ -19,10 +19,15 @@ require_once $_tests_dir . '/includes/functions.php';
 
 function _register_theme() {
 
-	$theme_dir = dirname( dirname( __FILE__ ) );
+	$theme_dir = dirname( __DIR__ );
 	$current_theme = basename( $theme_dir );
+	$theme_root = dirname( $theme_dir );
 
-	register_theme_directory( dirname( $theme_dir ) );
+	add_filter( 'theme_root', function() use ( $theme_root ) {
+		return $theme_root;
+	} );
+
+	register_theme_directory( $theme_root );
 
 	add_filter( 'pre_option_template', function() use ( $current_theme ) {
 		return $current_theme;


### PR DESCRIPTION
Closes #114 

Adds `theme_root` filter to `templates/theme-bootstrap.mustache` (tests/bootstrap.php) to make sure theme's `functions.php` gets loaded.