### PR TITLE
v1.1.2 prerelease: refresh test suite, require wp-cli ^1.5.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,19 +20,18 @@
         "psr-4": {
             "": "src/"
         },
-        "files": [
-            "scaffold-command.php"
-        ]
+        "files": [ "scaffold-command.php" ]
     },
     "require": {},
     "require-dev": {
         "behat/behat": "~2.5",
-        "wp-cli/wp-cli": "*"
+        "wp-cli/wp-cli": "^1.5"
     },
     "extra": {
         "branch-alias": {
             "dev-master": "1.x-dev"
         },
+        "bundled": true,
         "commands": [
             "scaffold",
             "scaffold _s",
@@ -43,7 +42,6 @@
             "scaffold post-type",
             "scaffold taxonomy",
             "scaffold theme-tests"
-        ],
-        "bundled": true
+        ]
     }
 }

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -87,8 +87,9 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 	private $running_procs = array();
 
 	/**
-	 * Array of variables available as {VARIABLE_NAME}. Some are always set: CORE_CONFIG_SETTINGS, SRC_DIR, CACHE_DIR, WP_VERSION-version-latest. Some are step-dependent:
-	 * RUN_DIR, SUITE_CACHE_DIR, COMPOSER_LOCAL_REPOSITORY, PHAR_PATH. Scenarios can define their own variables using "Given save" steps. Variables are reset for each scenario.
+	 * Array of variables available as {VARIABLE_NAME}. Some are always set: CORE_CONFIG_SETTINGS, SRC_DIR, CACHE_DIR, WP_VERSION-version-latest.
+	 * Some are step-dependent: RUN_DIR, SUITE_CACHE_DIR, COMPOSER_LOCAL_REPOSITORY, PHAR_PATH. One is set on use: INVOKE_WP_CLI_WITH_PHP_ARGS-args.
+	 * Scenarios can define their own variables using "Given save" steps. Variables are reset for each scenario.
 	 */
 	public $variables = array();
 
@@ -117,8 +118,9 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 		// Ensure we're using the expected `wp` binary
 		$bin_dir = getenv( 'WP_CLI_BIN_DIR' ) ?: realpath( __DIR__ . '/../../bin' );
 		$vendor_dir = realpath( __DIR__ . '/../../vendor/bin' );
+		$path_separator = Utils\is_windows() ? ';' : ':';
 		$env = array(
-			'PATH' =>  $bin_dir . ':' . $vendor_dir . ':' . getenv( 'PATH' ),
+			'PATH' =>  $bin_dir . $path_separator . $vendor_dir . $path_separator . getenv( 'PATH' ),
 			'BEHAT_RUN' => 1,
 			'HOME' => sys_get_temp_dir() . '/wp-cli-home',
 		);
@@ -328,20 +330,57 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 	}
 
 	/**
-	 * Replace {VARIABLE_NAME}. Note that variable names can only contain uppercase letters and underscores (no numbers).
+	 * Replace standard {VARIABLE_NAME} variables and the special {INVOKE_WP_CLI_WITH_PHP_ARGS-args} and {WP_VERSION-version-latest} variables.
+	 * Note that standard variable names can only contain uppercase letters, digits and underscores and cannot begin with a digit.
 	 */
 	public function replace_variables( $str ) {
-		$ret = preg_replace_callback( '/\{([A-Z_]+)\}/', array( $this, '_replace_var' ), $str );
-		if ( false !== strpos( $str, '{WP_VERSION-' ) ) {
-			$ret = $this->_replace_wp_versions( $ret );
+		if ( false !== strpos( $str, '{INVOKE_WP_CLI_WITH_PHP_ARGS-' ) ) {
+			$str = $this->replace_invoke_wp_cli_with_php_args( $str );
 		}
-		return $ret;
+		$str = preg_replace_callback( '/\{([A-Z_][A-Z_0-9]*)\}/', array( $this, 'replace_var' ), $str );
+		if ( false !== strpos( $str, '{WP_VERSION-' ) ) {
+			$str = $this->replace_wp_versions( $str );
+		}
+		return $str;
+	}
+
+	/**
+	 * Substitute {INVOKE_WP_CLI_WITH_PHP_ARGS-args} variables.
+	 */
+	private function replace_invoke_wp_cli_with_php_args( $str ) {
+		static $phar_path = null, $shell_path = null;
+
+		if ( null === $phar_path ) {
+			$phar_path = false;
+			$phar_begin = '#!/usr/bin/env php';
+			$phar_begin_len = strlen( $phar_begin );
+			if ( ( $bin_dir = getenv( 'WP_CLI_BIN_DIR' ) ) && file_exists( $bin_dir . '/wp' ) && $phar_begin === file_get_contents( $bin_dir . '/wp', false, null, 0, $phar_begin_len ) ) {
+				$phar_path = $bin_dir . '/wp';
+			} else {
+				$src_dir = dirname( dirname( __DIR__ ) );
+				$bin_path = $src_dir . '/bin/wp';
+				$vendor_bin_path = $src_dir . '/vendor/bin/wp';
+				if ( file_exists( $bin_path ) && is_executable( $bin_path ) ) {
+					$shell_path = $bin_path;
+				} elseif ( file_exists( $vendor_bin_path ) && is_executable( $vendor_bin_path ) ) {
+					$shell_path = $vendor_bin_path;
+				} else {
+					$shell_path = 'wp';
+				}
+			}
+		}
+
+		$str = preg_replace_callback( '/{INVOKE_WP_CLI_WITH_PHP_ARGS-([^}]*)}/', function ( $matches ) use ( $phar_path, $shell_path ) {
+			return $phar_path ? "php {$matches[1]} {$phar_path}" : ( 'WP_CLI_PHP_ARGS=' . escapeshellarg( $matches[1] ) . ' ' . $shell_path );
+		}, $str );
+
+		return $str;
 	}
 
 	/**
 	 * Replace variables callback.
 	 */
-	private function _replace_var( $matches ) {
+	private function replace_var( $matches ) {
 		$cmd = $matches[0];
 
 		foreach ( array_slice( $matches, 1 ) as $key ) {
@@ -352,9 +391,9 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 	}
 
 	/**
-	 * Substitute "{WP_VERSION-version-latest}" variables.
+	 * Substitute {WP_VERSION-version-latest} variables.
 	 */
-	private function _replace_wp_versions( $str ) {
+	private function replace_wp_versions( $str ) {
 		static $wp_versions = null;
 		if ( null === $wp_versions ) {
 			$wp_versions = array();

--- a/features/bootstrap/Process.php
+++ b/features/bootstrap/Process.php
@@ -2,6 +2,8 @@
 
 namespace WP_CLI;
 
+use WP_CLI\Utils;
+
 /**
  * Run a system process, and learn what happened.
  */
@@ -67,7 +69,7 @@ class Process {
 	public function run() {
 		$start_time = microtime( true );
 
-		$proc = proc_open( $this->command, self::$descriptors, $pipes, $this->cwd, $this->env );
+		$proc = Utils\proc_open_compat( $this->command, self::$descriptors, $pipes, $this->cwd, $this->env );
 
 		$stdout = stream_get_contents( $pipes[1] );
 		fclose( $pipes[1] );

--- a/utils/behat-tags.php
+++ b/utils/behat-tags.php
@@ -31,17 +31,24 @@ function version_tags( $prefix, $current, $operator = '<' ) {
 	return $skip_tags;
 }
 
+$wp_version = getenv( 'WP_VERSION' );
 $wp_version_reqs = array();
-// Only apply @require-wp tags when WP_VERSION isn't 'latest' or 'nightly'
-// 'latest' and 'nightly' are expected to work with all features
-if ( ! in_array( getenv( 'WP_VERSION' ), array( 'latest', 'nightly', 'trunk' ), true ) ) {
-	$wp_version_reqs = version_tags( 'require-wp', getenv( 'WP_VERSION' ), '<' );
+// Only apply @require-wp tags when WP_VERSION isn't 'latest', 'nightly' or 'trunk'.
+// 'latest', 'nightly' and 'trunk' are expected to work with all features.
+if ( $wp_version && ! in_array( $wp_version, array( 'latest', 'nightly', 'trunk' ), true ) ) {
+	$wp_version_reqs = array_merge(
+		version_tags( 'require-wp', $wp_version, '<' ),
+		version_tags( 'less-than-wp', $wp_version, '>=' )
+	);
+} else {
+	// But make sure @less-than-wp tags always exist for those special cases. (Note: @less-than-wp-latest etc won't work and shouldn't be used).
+	$wp_version_reqs = array_merge( $wp_version_reqs, version_tags( 'less-than-wp', '9999', '>=' ) );
 }
 
 $skip_tags = array_merge(
 	$wp_version_reqs,
 	version_tags( 'require-php', PHP_VERSION, '<' ),
-	version_tags( 'less-than-php', PHP_VERSION, '>' )
+	version_tags( 'less-than-php', PHP_VERSION, '>=' ) // Note: this was '>' prior to WP-CLI 1.5.0 but the change is unlikely to cause BC issues as usually compared against major.minor only.
 );
 
 # Skip Github API tests if `GITHUB_TOKEN` not available because of rate limiting. See https://github.com/wp-cli/wp-cli/issues/1612


### PR DESCRIPTION
Refreshes test suite and normalizes composer.json, requiring `wp-cli/wp-cli` ^1.5.

1.1.2 pre-release changes for WP-CLI 1.5.0.