### PR TITLE
Use phpunit 6.5.6 for PHP 7.2 to get around core test incompat.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,11 @@ install:
 
 before_script:
   - composer validate
-  - curl -sSfL -o $TRAVIS_BUILD_DIR/vendor/bin/phpunit https://phar.phpunit.de/phpunit-6.5.6.phar && chmod +x $TRAVIS_BUILD_DIR/vendor/bin/phpunit
+  - |
+    # Use phpunit 6.5.6 for PHP 7.2 temporarily until core tests are compat https://core.trac.wordpress.org/ticket/43218.
+    if [[ ${TRAVIS_PHP_VERSION:0:3} = "7.2" ]]; then
+      curl -sSfL -o $TRAVIS_BUILD_DIR/vendor/bin/phpunit https://phar.phpunit.de/phpunit-6.5.6.phar && chmod +x $TRAVIS_BUILD_DIR/vendor/bin/phpunit
+    fi
 
 script:
   - bash bin/test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,7 @@ install:
 
 before_script:
   - composer validate
+  - curl -sSfL -o $TRAVIS_BUILD_DIR/vendor/bin/phpunit https://phar.phpunit.de/phpunit-6.5.6.phar && chmod +x $TRAVIS_BUILD_DIR/vendor/bin/phpunit
 
 script:
   - bash bin/test.sh


### PR DESCRIPTION
See https://github.com/wp-cli/scaffold-command/pull/118#issuecomment-366536116 and https://core.trac.wordpress.org/ticket/43218

Temporary fix to use phpunit 6.5.6 if PHP 7.2 until the core test suite is made ~PHP 7.2~ phpunit 7.0.0 compat. Will need to be merged into outstanding PRs.