### PR TITLE
Enable running scaffolded plugin tests from within a wp-develop instance

### DIFF
--- a/templates/plugin-bootstrap.mustache
+++ b/templates/plugin-bootstrap.mustache
@@ -7,6 +7,14 @@
 
 $_tests_dir = getenv( 'WP_TESTS_DIR' );
 
+// See if we're installed inside an existing WP dev instance.
+if ( ! $_tests_dir ) {
+	$_try_tests_dir = dirname( __FILE__ ) . '/../../../../../tests/phpunit';
+	if ( file_exists( $_try_tests_dir . '/includes/functions.php' ) ) {
+		$_tests_dir = $_try_tests_dir;
+	}
+}
+// Fallback.
 if ( ! $_tests_dir ) {
 	$_tests_dir = rtrim( sys_get_temp_dir(), '/\\' ) . '/wordpress-tests-lib';
 }


### PR DESCRIPTION
It is often useful to install a WP plugin inside a working WordPress development site (a clone of https://github.com/WordPress/wordpress-develop for example).  In fact, this is my preferred development setup for WP core and plugins.

This change makes the `phpunit` test suites of plugins created using `wp scaffold plugin` able to run in this configuration without any extra setup.

If someone can outline an approach for adding automated tests for this change, I am happy to add them.