### PR TITLE
get correct WP_TEST_DIR. Similarly plugin-bootstrap.mustache.

### DIFF
--- a/templates/theme-bootstrap.mustache
+++ b/templates/theme-bootstrap.mustache
@@ -6,12 +6,14 @@
  */
 
 $_tests_dir = getenv( 'WP_TESTS_DIR' );
+
 if ( ! $_tests_dir ) {
-	$_tests_dir = '/tmp/wordpress-tests-lib';
+	$_tests_dir = rtrim( sys_get_temp_dir(), '/\\' ) . '/wordpress-tests-lib';
 }
 
 if ( ! file_exists( $_tests_dir . '/includes/functions.php' ) ) {
-	throw new Exception( "Could not find $_tests_dir/includes/functions.php, have you run bin/install-wp-tests.sh ?" );
+	echo "Could not find $_tests_dir/includes/functions.php, have you run bin/install-wp-tests.sh ?" . PHP_EOL;
+	exit( 1 );
 }
 
 // Give access to tests_add_filter() function.


### PR DESCRIPTION
Related: #67 

correct WP_TESTS_DIR, similarly https://github.com/wp-cli/scaffold-command/blob/master/templates/plugin-bootstrap.mustache#L8-L17