### PR TITLE
Fix sed -i option

### DIFF
--- a/templates/install-wp-tests.sh
+++ b/templates/install-wp-tests.sh
@@ -95,7 +95,7 @@ install_wp() {
 install_test_suite() {
 	# portable in-place argument for both GNU sed and Mac OSX sed
 	if [[ $(uname -s) == 'Darwin' ]]; then
-		local ioption='-i .bak'
+		local ioption='-i.bak'
 	else
 		local ioption='-i'
 	fi


### PR DESCRIPTION
The -i syntax is: `-i[SUFFIX]`. There should be no space between `-i`
and the suffix. See [sed Command Line Options](https://www.gnu.org/software/sed/manual/sed.html#Command_002dLine-Options-1).

Before this fix, I saw the following error on macOS:

```
sed: -e expression #1, char 1: unknown command: `.'
```
