### PR TITLE
Exclude tests/test-sample.php via the phpunit.xml.dist file

### DIFF
--- a/features/scaffold-plugin-tests.feature
+++ b/features/scaffold-plugin-tests.feature
@@ -35,7 +35,10 @@ Feature: Scaffold plugin unit tests
       """
       install-wp-tests.sh
       """
-    And the {PLUGIN_DIR}/hello-world/phpunit.xml.dist file should exist
+    And the {PLUGIN_DIR}/hello-world/phpunit.xml.dist file should contain:
+      """
+      <exclude>./tests/test-sample.php</exclude>
+      """
     And the {PLUGIN_DIR}/hello-world/phpcs.xml.dist file should exist
     And the {PLUGIN_DIR}/hello-world/circle.yml file should not exist
     And the {PLUGIN_DIR}/hello-world/.circleci directory should not exist
@@ -78,6 +81,12 @@ Feature: Scaffold plugin unit tests
     Then STDOUT should be:
       """
       executable
+      """
+
+    When I run `cd {PLUGIN_DIR}/hello-world; WP_TESTS_DIR=/tmp/behat-wordpress-tests-lib phpunit`
+    Then STDOUT should contain:
+      """
+      No tests executed!
       """
 
   Scenario: Scaffold plugin tests with Circle as the provider, part one

--- a/features/scaffold-plugin-tests.feature
+++ b/features/scaffold-plugin-tests.feature
@@ -83,12 +83,6 @@ Feature: Scaffold plugin unit tests
       executable
       """
 
-    When I run `cd {PLUGIN_DIR}/hello-world; WP_TESTS_DIR=/tmp/behat-wordpress-tests-lib phpunit`
-    Then STDOUT should contain:
-      """
-      No tests executed!
-      """
-
   Scenario: Scaffold plugin tests with Circle as the provider, part one
     Given a WP install
     And I run `wp scaffold plugin hello-world --ci=circle`

--- a/features/scaffold-theme-tests.feature
+++ b/features/scaffold-theme-tests.feature
@@ -32,7 +32,10 @@ Feature: Scaffold theme unit tests
       """
       install-wp-tests.sh
       """
-    And the {THEME_DIR}/p2child/phpunit.xml.dist file should exist
+    And the {THEME_DIR}/p2child/phpunit.xml.dist file should contain:
+      """
+      <exclude>./tests/test-sample.php</exclude>
+      """
     And the {THEME_DIR}/p2child/phpcs.xml.dist file should exist
     And the {THEME_DIR}/p2child/circle.yml file should not exist
     And the {THEME_DIR}/p2child/.circleci directory should not exist
@@ -97,7 +100,7 @@ Feature: Scaffold theme unit tests
       """
     And STDOUT should contain:
       """
-      OK (1 test, 1 assertion)
+      No tests executed!
       """
 
     When I run `cd {THEME_DIR}/p2child; WP_MULTISITE=1 WP_TESTS_DIR=/tmp/behat-wordpress-tests-lib phpunit`
@@ -111,7 +114,7 @@ Feature: Scaffold theme unit tests
       """
     And STDOUT should contain:
       """
-      OK (1 test, 1 assertion)
+      No tests executed!
       """
 
   Scenario: Scaffold theme tests invalid theme

--- a/templates/phpunit.xml.dist
+++ b/templates/phpunit.xml.dist
@@ -10,6 +10,7 @@
 	<testsuites>
 		<testsuite>
 			<directory prefix="test-" suffix=".php">./tests/</directory>
+			<exclude>./tests/test-sample.php</exclude>
 		</testsuite>
 	</testsuites>
 </phpunit>


### PR DESCRIPTION
This commit adds ./tests/test-sample.php as an exclusion in the phpunit.xml.dist file, preventing it from executing by default when developers run PHPUnit.

Keeping the sample file can be helpful for projects (for instance, if the project is using a custom base test case and/or namespaces), but constantly asserting that true is, in fact, true isn't helpful.