### PR TITLE
Add PHP 7.2 to CI templates

### DIFF
--- a/features/scaffold-plugin-tests.feature
+++ b/features/scaffold-plugin-tests.feature
@@ -58,6 +58,8 @@ Feature: Scaffold plugin unit tests
       """
       matrix:
         include:
+          - php: 7.2
+            env: WP_VERSION=latest
           - php: 7.1
             env: WP_VERSION=latest
           - php: 7.0
@@ -194,6 +196,16 @@ Feature: Scaffold plugin unit tests
           - step:
               image: php:7.1
               name: "PHP 7.1"
+              script:
+                # Install Dependencies
+                - docker-php-ext-install mysqli
+                - apt-get update && apt-get install -y subversion --no-install-recommends
+      """
+    And the {PLUGIN_DIR}/bitbucket-pipelines.yml file should contain:
+      """
+          - step:
+              image: php:7.2
+              name: "PHP 7.2"
               script:
                 # Install Dependencies
                 - docker-php-ext-install mysqli

--- a/features/scaffold-theme-tests.feature
+++ b/features/scaffold-theme-tests.feature
@@ -55,6 +55,8 @@ Feature: Scaffold theme unit tests
       """
       matrix:
         include:
+          - php: 7.2
+            env: WP_VERSION=latest
           - php: 7.1
             env: WP_VERSION=latest
           - php: 7.0
@@ -187,6 +189,16 @@ Feature: Scaffold theme unit tests
           - step:
               image: php:7.1
               name: "PHP 7.1"
+              script:
+                # Install Dependencies
+                - docker-php-ext-install mysqli
+                - apt-get update && apt-get install -y subversion --no-install-recommends
+      """
+    And the {THEME_DIR}/p2child/bitbucket-pipelines.yml file should contain:
+      """
+          - step:
+              image: php:7.2
+              name: "PHP 7.2"
               script:
                 # Install Dependencies
                 - docker-php-ext-install mysqli

--- a/features/scaffold.feature
+++ b/features/scaffold.feature
@@ -447,6 +447,8 @@ Feature: WordPress code scaffolding
       """
       matrix:
         include:
+          - php: 7.2
+            env: WP_VERSION=latest
           - php: 7.1
             env: WP_VERSION=latest
           - php: 7.0

--- a/templates/plugin-bitbucket.mustache
+++ b/templates/plugin-bitbucket.mustache
@@ -96,6 +96,38 @@ pipelines:
         services:
           - database
 
+    - step:
+        image: php:7.2
+        name: "PHP 7.3"
+        script:
+          # Install Dependencies
+          - docker-php-ext-install mysqli
+          - apt-get update && apt-get install -y subversion --no-install-recommends
+
+          # Install PHPCS
+          - curl -o /usr/local/bin/phpcs -fSL https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar && chmod +x /usr/local/bin/phpcs
+          - phpcs --version
+
+          # Install WordPress Coding Standards
+          - WPCS_VERSION=0.14.1
+          - curl -o wpcs.tar.gz -fSL "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/archive/${WPCS_VERSION}.tar.gz"
+          - mkdir -p /var/wpcs && tar -xzf wpcs.tar.gz --directory /var/wpcs --strip-components 1 && rm wpcs.tar.gz
+          - phpcs --config-set show_progress 1 && phpcs --config-set colors 1 && phpcs --config-set installed_paths /var/wpcs
+
+          ## Run PHPCS
+          - phpcs
+
+          # Install PHPUnit
+          - PHPUNIT_VERSION=6.5.6
+          - curl -o /usr/local/bin/phpunit "https://phar.phpunit.de/phpunit-${PHPUNIT_VERSION}.phar" && chmod +x /usr/local/bin/phpunit
+          - phpunit --version
+
+          ## Run PHPUnit
+          - bash bin/install-wp-tests.sh wordpress_tests root root 127.0.0.1 latest true
+          - phpunit
+        services:
+          - database
+
 definitions:
   services:
     database:

--- a/templates/plugin-circle.mustache
+++ b/templates/plugin-circle.mustache
@@ -5,6 +5,7 @@ workflows:
       - php56-build
       - php70-build
       - php71-build
+      - php72-build
 
 version: 2
 jobs:
@@ -81,6 +82,39 @@ jobs:
   php71-build:
     docker:
       - image: circleci/php:7.1
+      - image: circleci/mysql:5.7
+    environment:
+      - WP_TESTS_DIR: "/tmp/wordpress-tests-lib"
+      - WP_CORE_DIR: "/tmp/wordpress/"
+    steps:
+      - checkout
+      - run:
+          name: "Setup Environment Variables"
+          command: |
+            echo "export PATH=$HOME/.composer/vendor/bin:$PATH" >> $BASH_ENV
+            source /home/circleci/.bashrc
+      - run:
+          name: "Install Dependencies"
+          command: |
+            sudo apt-get update && sudo apt-get install subversion
+            sudo docker-php-ext-install mysqli
+            sudo sh -c "printf '\ndeb http://ftp.us.debian.org/debian sid main\n' >> /etc/apt/sources.list"
+            sudo apt-get update && sudo apt-get install mysql-client-5.7
+      - run:
+          name: "Run Tests"
+          command: |
+            composer global require "phpunit/phpunit=5.7.*"
+            composer global require wp-coding-standards/wpcs
+            phpcs --config-set installed_paths $HOME/.composer/vendor/wp-coding-standards/wpcs
+            phpcs
+            rm -rf $WP_TESTS_DIR $WP_CORE_DIR
+            bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest
+            phpunit
+            WP_MULTISITE=1 phpunit
+
+  php72-build:
+    docker:
+      - image: circleci/php:7.2
       - image: circleci/mysql:5.7
     environment:
       - WP_TESTS_DIR: "/tmp/wordpress-tests-lib"

--- a/templates/plugin-gitlab.mustache
+++ b/templates/plugin-gitlab.mustache
@@ -55,3 +55,11 @@ PHPunit:PHP7.1:MySQL:
   script:
   - phpcs
   - phpunit
+
+PHPunit:PHP7.2:MySQL:
+  image: tetraweb/php:7.2
+  services:
+    - mysql:5.6
+  script:
+  - phpcs
+  - phpunit

--- a/templates/plugin-travis.mustache
+++ b/templates/plugin-travis.mustache
@@ -18,6 +18,8 @@ cache:
 
 matrix:
   include:
+    - php: 7.2
+      env: WP_VERSION=latest
     - php: 7.1
       env: WP_VERSION=latest
     - php: 7.0


### PR DESCRIPTION
WordPress 4.9.5 bumped the recommended PHP version to 7.2, so themes and plugins should probably make a point of supporting them.

This PR adds PHP 7.2 to the testing matricies for all of the CI providers, using the same settings as we were using for PHP 7.1.