### PR TITLE
Bump the Travis CI memory limit to 2048MB

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,9 @@ before_install:
     else
       echo "xdebug.ini does not exist"
     fi
+  - |
+    # Raise PHP memory limit to 256MB
+    echo 'memory_limit = 2048M' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
 
 install:
   - composer require wp-cli/wp-cli:dev-master

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ before_install:
       echo "xdebug.ini does not exist"
     fi
   - |
-    # Raise PHP memory limit to 256MB
+    # Raise PHP memory limit to 2048MB.
     echo 'memory_limit = 2048M' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
 
 install:


### PR DESCRIPTION
The Behat tests are currently running out of memory in PHP 5.3 environments, as noted by @schlessera in wp-cli/entity-command#161.

This uses the same code as wp-cli/entity-command@f449ea9 to raise the memory_limit within Travis' PHP configuration.