### PR TITLE
Add function_exists() check to block PHP template

### DIFF
--- a/templates/block-php.mustache
+++ b/templates/block-php.mustache
@@ -13,6 +13,10 @@
  * @see https://wordpress.org/gutenberg/handbook/blocks/writing-your-first-block-type/#enqueuing-block-scripts
  */
 function {{machine_name}}_block_init() {
+	// Skip block registration if Gutenberg is not enabled/merged.
+	if ( ! function_exists( 'register_block_type' ) ) {
+		return;
+	}
 	{{#plugin}}
 	$dir = dirname( __FILE__ );
 	{{/plugin}}


### PR DESCRIPTION
Check for the existance of the function register_block_type() in the PHP
code when creating a block.

Since Gutenberg has not yet been merged into core, currently the function
register_block_type() is only defined if the Gutenberg plugin is installed
and activated.

See #146

<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->
