### PR TITLE
Refactor circleci with aliases to reduce redundancy

### DIFF
--- a/templates/plugin-circle.mustache
+++ b/templates/plugin-circle.mustache
@@ -8,28 +8,55 @@ workflows:
       - php72-build
 
 version: 2
-jobs:
-  php56-build:
-    docker:
-      - image: circleci/php:5.6
-      - image: circleci/mysql:5.7
+
+job-references:
+  mysql_image: &mysql_image
+    circleci/mysql:5.6
+
+  setup_environment: &setup_environment
+    name: "Setup Environment Variables"
+    command: |
+      echo "export PATH=$HOME/.composer/vendor/bin:$PATH" >> $BASH_ENV
+      source /home/circleci/.bashrc
+
+  install_dependencies: &install_dependencies
+    name: "Install Dependencies"
+    command: |
+      sudo apt-get update && sudo apt-get install subversion
+      sudo docker-php-ext-install mysqli
+      sudo sh -c "printf '\ndeb http://ftp.us.debian.org/debian sid main\n' >> /etc/apt/sources.list"
+      sudo apt-get update && sudo apt-get install mysql-client-5.7
+
+  php_job: &php_job
     environment:
       - WP_TESTS_DIR: "/tmp/wordpress-tests-lib"
       - WP_CORE_DIR: "/tmp/wordpress/"
     steps:
       - checkout
+      - run: *setup_environment
+      - run: *install_dependencies
       - run:
-          name: "Setup Environment Variables"
+          name: "Run Tests"
           command: |
-            echo "export PATH=$HOME/.composer/vendor/bin:$PATH" >> $BASH_ENV
-            source /home/circleci/.bashrc
-      - run:
-          name: "Install Dependencies"
-          command: |
-            sudo apt-get update && sudo apt-get install subversion
-            sudo docker-php-ext-install mysqli
-            sudo sh -c "printf '\ndeb http://ftp.us.debian.org/debian sid main\n' >> /etc/apt/sources.list"
-            sudo apt-get update && sudo apt-get install mysql-client-5.7
+            composer global require "phpunit/phpunit=5.7.*"
+            composer global require wp-coding-standards/wpcs
+            phpcs --config-set installed_paths $HOME/.composer/vendor/wp-coding-standards/wpcs
+            phpcs
+            rm -rf $WP_TESTS_DIR $WP_CORE_DIR
+            bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest
+            phpunit
+            WP_MULTISITE=1 phpunit
+
+jobs:
+  php56-build:
+    <<: *php_job
+    docker:
+      - image: circleci/php:5.6
+      - image: *mysql_image
+    steps:
+      - checkout
+      - run: *setup_environment
+      - run: *install_dependencies
       - run:
           name: "Run Tests"
           command: |
@@ -47,100 +74,19 @@ jobs:
             {{/wp_versions_to_test}}
 
   php70-build:
+    <<: *php_job
     docker:
       - image: circleci/php:7.0
-      - image: circleci/mysql:5.7
-    environment:
-      - WP_TESTS_DIR: "/tmp/wordpress-tests-lib"
-      - WP_CORE_DIR: "/tmp/wordpress/"
-    steps:
-      - checkout
-      - run:
-          name: "Setup Environment Variables"
-          command: |
-            echo "export PATH=$HOME/.composer/vendor/bin:$PATH" >> $BASH_ENV
-            source /home/circleci/.bashrc
-      - run:
-          name: "Install Dependencies"
-          command: |
-            sudo apt-get update && sudo apt-get install subversion
-            sudo docker-php-ext-install mysqli
-            sudo sh -c "printf '\ndeb http://ftp.us.debian.org/debian sid main\n' >> /etc/apt/sources.list"
-            sudo apt-get update && sudo apt-get install mysql-client-5.7
-      - run:
-          name: "Run Tests"
-          command: |
-            composer global require "phpunit/phpunit=5.7.*"
-            composer global require wp-coding-standards/wpcs
-            phpcs --config-set installed_paths $HOME/.composer/vendor/wp-coding-standards/wpcs
-            phpcs
-            rm -rf $WP_TESTS_DIR $WP_CORE_DIR
-            bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest
-            phpunit
-            WP_MULTISITE=1 phpunit
+      - image: *mysql_image
 
   php71-build:
+    <<: *php_job
     docker:
       - image: circleci/php:7.1
-      - image: circleci/mysql:5.7
-    environment:
-      - WP_TESTS_DIR: "/tmp/wordpress-tests-lib"
-      - WP_CORE_DIR: "/tmp/wordpress/"
-    steps:
-      - checkout
-      - run:
-          name: "Setup Environment Variables"
-          command: |
-            echo "export PATH=$HOME/.composer/vendor/bin:$PATH" >> $BASH_ENV
-            source /home/circleci/.bashrc
-      - run:
-          name: "Install Dependencies"
-          command: |
-            sudo apt-get update && sudo apt-get install subversion
-            sudo docker-php-ext-install mysqli
-            sudo sh -c "printf '\ndeb http://ftp.us.debian.org/debian sid main\n' >> /etc/apt/sources.list"
-            sudo apt-get update && sudo apt-get install mysql-client-5.7
-      - run:
-          name: "Run Tests"
-          command: |
-            composer global require "phpunit/phpunit=5.7.*"
-            composer global require wp-coding-standards/wpcs
-            phpcs --config-set installed_paths $HOME/.composer/vendor/wp-coding-standards/wpcs
-            phpcs
-            rm -rf $WP_TESTS_DIR $WP_CORE_DIR
-            bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest
-            phpunit
-            WP_MULTISITE=1 phpunit
+      - image: *mysql_image
 
   php72-build:
+    <<: *php_job
     docker:
       - image: circleci/php:7.2
-      - image: circleci/mysql:5.7
-    environment:
-      - WP_TESTS_DIR: "/tmp/wordpress-tests-lib"
-      - WP_CORE_DIR: "/tmp/wordpress/"
-    steps:
-      - checkout
-      - run:
-          name: "Setup Environment Variables"
-          command: |
-            echo "export PATH=$HOME/.composer/vendor/bin:$PATH" >> $BASH_ENV
-            source /home/circleci/.bashrc
-      - run:
-          name: "Install Dependencies"
-          command: |
-            sudo apt-get update && sudo apt-get install subversion
-            sudo docker-php-ext-install mysqli
-            sudo sh -c "printf '\ndeb http://ftp.us.debian.org/debian sid main\n' >> /etc/apt/sources.list"
-            sudo apt-get update && sudo apt-get install mysql-client-5.7
-      - run:
-          name: "Run Tests"
-          command: |
-            composer global require "phpunit/phpunit=5.7.*"
-            composer global require wp-coding-standards/wpcs
-            phpcs --config-set installed_paths $HOME/.composer/vendor/wp-coding-standards/wpcs
-            phpcs
-            rm -rf $WP_TESTS_DIR $WP_CORE_DIR
-            bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest
-            phpunit
-            WP_MULTISITE=1 phpunit
+      - image: *mysql_image


### PR DESCRIPTION
Reduces the redundancy in the Circle CI file making it easier to add additional PHP jobs. See #148