### PR TITLE
Remove 'wp-blocks' from style dependency

### DIFF
--- a/templates/block-php.mustache
+++ b/templates/block-php.mustache
@@ -50,9 +50,7 @@ function {{machine_name}}_block_init() {
 		{{#theme}}
 		get_template_directory_uri() . "/blocks/$editor_css",
 		{{/theme}}
-		array(
-			'wp-blocks',
-		),
+		array(),
 		filemtime( "$dir/$editor_css" )
 	);
 
@@ -65,9 +63,7 @@ function {{machine_name}}_block_init() {
 		{{#theme}}
 		get_template_directory_uri() . "/blocks/$style_css",
 		{{/theme}}
-		array(
-			'wp-blocks',
-		),
+		array(),
 		filemtime( "$dir/$style_css" )
 	);
 


### PR DESCRIPTION
`wp-blocks` dependency is not required by block

https://github.com/WordPress/gutenberg/pull/6778

https://wordpress.org/gutenberg/handbook/blocks/generate-blocks-with-wp-cli/#examples