### PR TITLE
fixes #139 adding --woocommerce flag to scaffold _s command

### DIFF
--- a/features/scaffold.feature
+++ b/features/scaffold.feature
@@ -355,7 +355,7 @@ Feature: WordPress code scaffolding
     Given I run `wp theme path`
     And save STDOUT as {THEME_DIR}
 
-    When I run `wp scaffold _s starter-theme --woocommerce
+    When I run `wp scaffold _s starter-theme --woocommerce`
     Then STDOUT should contain:
       """
       Success: Created theme 'Starter-theme'.

--- a/features/scaffold.feature
+++ b/features/scaffold.feature
@@ -350,6 +350,19 @@ Feature: WordPress code scaffolding
       """
     And the {THEME_DIR}/starter-theme/sass directory should exist
 
+  Scenario: Scaffold starter code for a WooCommerce theme
+    Given a WP install
+    Given I run `wp theme path`
+    And save STDOUT as {THEME_DIR}
+
+    When I run `wp scaffold _s starter-theme --woocommerce
+    Then STDOUT should contain:
+      """
+      Success: Created theme 'Starter-theme'.
+      """
+    And the {THEME_DIR}/starter-theme/woocommerce.css file should exist
+    And the {THEME_DIR}/starter-theme/inc/woocommerce.php file should exist
+
   Scenario: Scaffold starter code for a theme and activate it
     Given a WP install
     When I run `wp scaffold _s starter-theme --activate`

--- a/src/Scaffold_Command.php
+++ b/src/Scaffold_Command.php
@@ -340,7 +340,7 @@ class Scaffold_Command extends WP_CLI_Command {
 	 * : Include stylesheets as SASS.
 	 *
 	 * [--woocommerce]
-	 * : Include WooCommerce boilerplate files
+	 * : Include WooCommerce boilerplate files.
 	 *
 	 * [--force]
 	 * : Overwrite files that already exist.

--- a/src/Scaffold_Command.php
+++ b/src/Scaffold_Command.php
@@ -339,6 +339,9 @@ class Scaffold_Command extends WP_CLI_Command {
 	 * [--sassify]
 	 * : Include stylesheets as SASS.
 	 *
+	 * [--woocommerce]
+	 * : Include WooCommerce boilerplate files
+	 *
 	 * [--force]
 	 * : Overwrite files that already exist.
 	 *
@@ -390,6 +393,10 @@ class Scaffold_Command extends WP_CLI_Command {
 		$body['underscoresme_generate']        = "1";
 		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'sassify' ) ) {
 			$body['underscoresme_sass'] = 1;
+		}
+
+		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'woocommerce' ) ) {
+			$body['underscoresme_woocommerce'] = 1;
 		}
 
 		$tmpfname = wp_tempnam( $url );


### PR DESCRIPTION
Added the new --woocommerce flag to the scaffold _s command.

First time writing behat tests, so hopefully I got them right. The only test I wrote was basically to assert two of the WooCommerce files existed. Not sure if the tests should be more in depth than that, or if there should also be a test to assert the WooCommerce files _don't_ exist when the flag isn't present.