### PR TITLE
Exclude string from escape warning

### DIFF
--- a/templates/plugin-bootstrap.mustache
+++ b/templates/plugin-bootstrap.mustache
@@ -12,7 +12,7 @@ if ( ! $_tests_dir ) {
 }
 
 if ( ! file_exists( $_tests_dir . '/includes/functions.php' ) ) {
-	echo "Could not find $_tests_dir/includes/functions.php, have you run bin/install-wp-tests.sh ?" . PHP_EOL;
+	echo "Could not find $_tests_dir/includes/functions.php, have you run bin/install-wp-tests.sh ?" . PHP_EOL; // WPCS: XSS ok.
 	exit( 1 );
 }
 


### PR DESCRIPTION
The bootstrap.php file generates an error in wpcs sniff because there are two unescapped items. This error is generated with the WordPress files are not loaded by the bootstrap file, so the escape functions are not available.

The solve is to use a line comment that will prevent that from generating an error in the sniff.

addresses https://github.com/wp-cli/scaffold-command/issues/109