### PR TITLE
PHPCS template: fix XML error in ruleset

### DIFF
--- a/templates/.phpcs.xml.dist
+++ b/templates/.phpcs.xml.dist
@@ -22,7 +22,7 @@
 	<rule ref="PHPCompatibilityWP"/>
 
 	<!-- Rules: WordPress Coding Standards -->
-	<!-- https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+	<!-- https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards -->
 	<!-- https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties -->
 	<config name="minimum_supported_wp_version" value="4.6"/>
 	<rule ref="WordPress">


### PR DESCRIPTION
As reported by @dimadin on [Slack](https://wordpress.slack.com/archives/C02RP4T41/p1534097387000006), when using the current `.phpcs.xml.dist` ruleset, a
`phpcs: Ruleset <path>/.phpcs.xml.dist is not valid`
error is thrown.

This was caused by an unclosed comment in the XML. This PR fixes it.

The PR can be tested by:
1. Save the current ruleset locally and try to use it to see the error.
2. Save the ruleset from this PR and try again. The ruleset error will be gone.