### PR TITLE
Fix syntax error in block-php.mustache

### DIFF
--- a/templates/block-php.mustache
+++ b/templates/block-php.mustache
@@ -31,7 +31,7 @@ function {{machine_name}}_block_init() {
 		plugins_url( $index_js, __FILE__ ),
 		{{/plugin}}
 		{{#theme}}
-		get_template_directory_uri() . "/blocks/$index_js,
+		get_template_directory_uri() . "/blocks/$index_js",
 		{{/theme}}
 		array(
 			'wp-blocks',


### PR DESCRIPTION
fixes https://github.com/wp-cli/scaffold-command/issues/175