### PR TITLE
Allow for `installation` as well as `install`

### DIFF
--- a/features/scaffold.feature
+++ b/features/scaffold.feature
@@ -44,7 +44,7 @@ Feature: WordPress code scaffolding
     When I try `wp scaffold child-theme hello-world --parent_theme=just-test --enable-network --quiet`
     Then STDERR should contain:
       """
-      Error: This is not a multisite install.
+      Error: This is not a multisite installation.
       """
     And the return code should be 1
 

--- a/features/scaffold.feature
+++ b/features/scaffold.feature
@@ -44,7 +44,7 @@ Feature: WordPress code scaffolding
     When I try `wp scaffold child-theme hello-world --parent_theme=just-test --enable-network --quiet`
     Then STDERR should contain:
       """
-      Error: This is not a multisite installation.
+      Error: This is not a multisite install
       """
     And the return code should be 1
 


### PR DESCRIPTION
Related to [#4541](https://github.com/wp-cli/wp-cli/issues/4541) in wp-cli.