### PR TITLE
Ignore 'node_modules' in PHPCS XML file

### DIFF
--- a/templates/.phpcs.xml.dist
+++ b/templates/.phpcs.xml.dist
@@ -5,6 +5,7 @@
 	<!-- What to scan -->
 	<file>.</file>
 	<exclude-pattern>/vendor/</exclude-pattern>
+	<exclude-pattern>/node_modules/</exclude-pattern>
 
 	<!-- How to scan -->
 	<!-- Usage instructions: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage -->


### PR DESCRIPTION
The `wp-i18n` node module has some PHP that gets flagged.