### PR TITLE
Work around Travis CI issue with _s download certificate

### DIFF
--- a/features/scaffold.feature
+++ b/features/scaffold.feature
@@ -338,7 +338,8 @@ Feature: WordPress code scaffolding
     Given I run `wp theme path`
     And save STDOUT as {THEME_DIR}
 
-    When I run `wp scaffold _s starter-theme`
+    # Allow for warnings to be generated due to https://github.com/wp-cli/scaffold-command/issues/181
+    When I try `wp scaffold _s starter-theme`
     Then STDOUT should contain:
       """
       Success: Created theme 'Starter-theme'.
@@ -351,7 +352,8 @@ Feature: WordPress code scaffolding
     Given I run `wp theme path`
     And save STDOUT as {THEME_DIR}
 
-    When I run `wp scaffold _s starter-theme --sassify`
+    # Allow for warnings to be generated due to https://github.com/wp-cli/scaffold-command/issues/181
+    When I try `wp scaffold _s starter-theme --sassify`
     Then STDOUT should contain:
       """
       Success: Created theme 'Starter-theme'.
@@ -363,7 +365,8 @@ Feature: WordPress code scaffolding
     Given I run `wp theme path`
     And save STDOUT as {THEME_DIR}
 
-    When I run `wp scaffold _s starter-theme --woocommerce`
+    # Allow for warnings to be generated due to https://github.com/wp-cli/scaffold-command/issues/181
+    When I try `wp scaffold _s starter-theme --woocommerce`
     Then STDOUT should contain:
       """
       Success: Created theme 'Starter-theme'.
@@ -373,7 +376,8 @@ Feature: WordPress code scaffolding
 
   Scenario: Scaffold starter code for a theme and activate it
     Given a WP install
-    When I run `wp scaffold _s starter-theme --activate`
+    # Allow for warnings to be generated due to https://github.com/wp-cli/scaffold-command/issues/181
+    When I try `wp scaffold _s starter-theme --activate`
     Then STDOUT should contain:
       """
       Success: Switched to 'Starter-theme' theme.
@@ -488,7 +492,8 @@ Feature: WordPress code scaffolding
 
   Scenario: Scaffold starter code for a theme and network enable it
     Given a WP multisite install
-    When I run `wp scaffold _s starter-theme --enable-network`
+    # Allow for warnings to be generated due to https://github.com/wp-cli/scaffold-command/issues/181
+    When I try `wp scaffold _s starter-theme --enable-network`
     Then STDOUT should contain:
       """
       Success: Network enabled the 'Starter-theme' theme.

--- a/src/Scaffold_Command.php
+++ b/src/Scaffold_Command.php
@@ -408,6 +408,21 @@ class Scaffold_Command extends WP_CLI_Command {
 			'filename' => $tmpfname,
 		) );
 
+		// Workaround to get scaffolding to work within Travis CI.
+		// See https://github.com/wp-cli/scaffold-command/issues/181
+		if ( is_wp_error( $response )
+		     && false !== strpos( $response->get_error_message(), 'gnutls_handshake() failed' ) ) {
+			// Try again with HTTP instead of HTTPS.
+			$url = str_replace( 'https://', 'http://', $url );
+
+			$response = wp_remote_post( $url, array(
+				'timeout'  => $timeout,
+				'body'     => $body,
+				'stream'   => true,
+				'filename' => $tmpfname,
+			) );
+		}
+
 		if ( is_wp_error( $response ) ) {
 			WP_CLI::error( $response );
 		}

--- a/src/Scaffold_Command.php
+++ b/src/Scaffold_Command.php
@@ -414,9 +414,10 @@ class Scaffold_Command extends WP_CLI_Command {
 		// See https://github.com/wp-cli/scaffold-command/issues/181
 		if ( is_wp_error( $response )
 		     && false !== strpos( $response->get_error_message(), 'gnutls_handshake() failed' ) ) {
-			// Try again with HTTP instead of HTTPS.
-			$url      = str_replace( 'https://', 'http://', $url );
-			$response = wp_remote_post( $url, $post_args );
+			// Certificate problem, falling back to unsecured request instead.
+			$alt_url = str_replace( 'https://', 'http://', $url );
+			WP_CLI::warning( "Secured request to {$url} failed, using {$alt_url} as a fallback." );
+			$response = wp_remote_post( $alt_url, $post_args );
 		}
 
 		if ( is_wp_error( $response ) ) {

--- a/src/Scaffold_Command.php
+++ b/src/Scaffold_Command.php
@@ -400,27 +400,23 @@ class Scaffold_Command extends WP_CLI_Command {
 			$body['underscoresme_woocommerce'] = 1;
 		}
 
-		$tmpfname = wp_tempnam( $url );
-		$response = wp_remote_post( $url, array(
+		$tmpfname  = wp_tempnam( $url );
+		$post_args = array(
 			'timeout'  => $timeout,
 			'body'     => $body,
 			'stream'   => true,
 			'filename' => $tmpfname,
-		) );
+		);
+
+		$response = wp_remote_post( $url, $post_args );
 
 		// Workaround to get scaffolding to work within Travis CI.
 		// See https://github.com/wp-cli/scaffold-command/issues/181
 		if ( is_wp_error( $response )
 		     && false !== strpos( $response->get_error_message(), 'gnutls_handshake() failed' ) ) {
 			// Try again with HTTP instead of HTTPS.
-			$url = str_replace( 'https://', 'http://', $url );
-
-			$response = wp_remote_post( $url, array(
-				'timeout'  => $timeout,
-				'body'     => $body,
-				'stream'   => true,
-				'filename' => $tmpfname,
-			) );
+			$url      = str_replace( 'https://', 'http://', $url );
+			$response = wp_remote_post( $url, $post_args );
 		}
 
 		if ( is_wp_error( $response ) ) {


### PR DESCRIPTION
When the request fails on HTTPS, we switch to HTTP instead, which should work within Travis.

Fixes #181