### PR TITLE
Run `docker-php-ext-install` with `sudo -E` in CircleCI

### DIFF
--- a/templates/plugin-circle.mustache
+++ b/templates/plugin-circle.mustache
@@ -23,7 +23,7 @@ job-references:
     name: "Install Dependencies"
     command: |
       sudo apt-get update && sudo apt-get install subversion
-      sudo docker-php-ext-install mysqli
+      sudo -E docker-php-ext-install mysqli
       sudo sh -c "printf '\ndeb http://ftp.us.debian.org/debian sid main\n' >> /etc/apt/sources.list"
       sudo apt-get update && sudo apt-get install mysql-client-5.7
 


### PR DESCRIPTION
Doing so ensures environment variables are passed through and avoids
cryptic build failures.

See https://github.com/docker-library/php/issues/750#issuecomment-439364320