### PR TITLE
Ignore various JavaScript config files in plugin `.distignore`

### DIFF
--- a/templates/plugin-distignore.mustache
+++ b/templates/plugin-distignore.mustache
@@ -1,6 +1,9 @@
 # A set of files you probably don't want in your WordPress.org distribution
+.babelrc
 .distignore
 .editorconfig
+.eslintignore
+.eslintrc
 .git
 .gitignore
 .gitlab-ci.yml
@@ -25,6 +28,7 @@ phpcs.xml
 .phpcs.xml.dist
 phpcs.xml.dist
 README.md
+webpack.config.js
 wp-cli.local.yml
 yarn.lock
 tests


### PR DESCRIPTION
Specifically:
* `.babelrc`
* `.eslintignore`
* `.eslintignore`
* `.eslintignore`