### PR TITLE
Add `dependencies.yml` to plugin `.distignore`

### DIFF
--- a/templates/plugin-distignore.mustache
+++ b/templates/plugin-distignore.mustache
@@ -17,6 +17,7 @@ bin
 .circleci/config.yml
 composer.json
 composer.lock
+dependencies.yml
 Gruntfile.js
 package.json
 package-lock.json


### PR DESCRIPTION
`dependencies.yml` corresponds with [Dependencies.io](https://www.dependencies.io/)
