### PR TITLE
Prevent creating unregisterable blocks due to invalid plugin slug

### DIFF
--- a/features/scaffold-block.feature
+++ b/features/scaffold-block.feature
@@ -31,6 +31,14 @@ Feature: WordPress block code scaffolding
       Error: Can't find 'unknown' plugin.
       """
 
+  Scenario: Scaffold a block for an invalid plugin slug
+    When I run `wp scaffold plugin plugin.name.with.dots`
+    And I try `wp scaffold block some-block --plugin=plugin.name.with.dots`
+    Then STDERR should contain:
+      """
+      Error: Invalid plugin name specified.
+      """
+
   Scenario: Scaffold a block for a specific plugin
     When I run `wp scaffold block the-green-mile --plugin=movies`
     Then the {PLUGIN_DIR}/blocks/the-green-mile.php file should exist
@@ -175,3 +183,4 @@ Feature: WordPress block code scaffolding
       """
       plugins_url
       """
+

--- a/src/Scaffold_Command.php
+++ b/src/Scaffold_Command.php
@@ -289,6 +289,12 @@ class Scaffold_Command extends WP_CLI_Command {
 			'theme'  => false,
 		) );
 
+		if ( isset( $control_args['plugin'] ) ) {
+			if ( ! preg_match( '/^[A-Za-z0-9\-]*$/', $control_args['plugin'] ) ) {
+				WP_CLI::error( "Invalid plugin name specified. Block work only if the plugin name contains lowercase alphanumeric characters or dashes" );
+			}
+		}
+
 		$data['namespace'] = $control_args['plugin'] ? $control_args['plugin'] : $this->get_theme_name( $control_args['theme'] );
 		$data['machine_name'] = $this->generate_machine_name( $slug );
 		$data['plugin'] = $control_args['plugin'] ? true : false;

--- a/src/Scaffold_Command.php
+++ b/src/Scaffold_Command.php
@@ -291,7 +291,7 @@ class Scaffold_Command extends WP_CLI_Command {
 
 		if ( isset( $control_args['plugin'] ) ) {
 			if ( ! preg_match( '/^[A-Za-z0-9\-]*$/', $control_args['plugin'] ) ) {
-				WP_CLI::error( "Invalid plugin name specified. Block work only if the plugin name contains lowercase alphanumeric characters or dashes" );
+				WP_CLI::error( 'Invalid plugin name specified. The block editor can only register blocks for plugins that have nothing but lowercase alphanumeric characters or dashes in their slug.' );
 			}
 		}
 


### PR DESCRIPTION
The purpose of this PR is to prevent nonworking gutenberg blocks.
More details here: https://github.com/wp-cli/scaffold-command/issues/191