### PR TITLE
Move PHP 5.4 tests from `WP_VERSION` `latest` to `5.1`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,4 +71,4 @@ jobs:
     - stage: test
       php: 5.4
       dist: precise
-      env: WP_VERSION=latest
+      env: WP_VERSION=5.1

--- a/features/install-wp-tests.feature
+++ b/features/install-wp-tests.feature
@@ -14,7 +14,7 @@ Feature: Scaffold install-wp-tests.sh tests
       """
     And the return code should be 1
 
-  @less-than-php-7.2
+  @require-php-5.6
   Scenario: Install latest version of WordPress
     Given a WP install
     And I run `wp plugin path`
@@ -76,7 +76,7 @@ Feature: Scaffold install-wp-tests.sh tests
     When I run `WP_TESTS_DIR=/tmp/behat-wordpress-tests-lib phpunit -c {PLUGIN_DIR}/hello-world/phpunit.xml.dist`
     Then the return code should be 0
 
-  @less-than-php-7.2
+  @require-php-5.6
   Scenario: Install WordPress from trunk
     Given a WP install
     And I run `wp plugin path`


### PR DESCRIPTION
Related wp-cli/wp-cli#5127