### PR TITLE
QA: don't unnecessarily create variables within a function call

### DIFF
--- a/src/Scaffold_Command.php
+++ b/src/Scaffold_Command.php
@@ -188,11 +188,9 @@ class Scaffold_Command extends WP_CLI_Command {
 
 			$force = \WP_CLI\Utils\get_flag_value( $assoc_args, 'force' );
 			$files_written = $this->create_files( array( $filename => $final_output ), $force );
-			$this->log_whether_files_written(
-				$files_written,
-				$skip_message = "Skipped creating '$filename'.",
-				$success_message = "Created '$filename'."
-			);
+			$skip_message    = "Skipped creating '$filename'.";
+			$success_message = "Created '$filename'.";
+			$this->log_whether_files_written( $files_written, $skip_message, $success_message );
 
 		} else {
 			// STDOUT
@@ -305,11 +303,9 @@ class Scaffold_Command extends WP_CLI_Command {
 			"$block_dir/$slug/editor.css" => self::mustache_render( 'block-editor-css.mustache', $data ),
 			"$block_dir/$slug/style.css" => self::mustache_render( 'block-style-css.mustache', $data ),
 		), $control_args['force'] );
-		$this->log_whether_files_written(
-			$files_written,
-			$skip_message = 'All block files were skipped.',
-			$success_message = "Created block '{$data['title_ucfirst']}'."
-		);
+		$skip_message    = 'All block files were skipped.';
+		$success_message = "Created block '{$data['title_ucfirst']}'.";
+		$this->log_whether_files_written( $files_written, $skip_message, $success_message );
 	}
 
 	/**
@@ -528,11 +524,9 @@ class Scaffold_Command extends WP_CLI_Command {
 			$theme_functions_path => self::mustache_render( 'child_theme_functions.mustache', $data ),
 			"$theme_dir/.editorconfig" => file_get_contents( self::get_template_path( '.editorconfig' ) ),
 		), $force );
-		$this->log_whether_files_written(
-			$files_written,
-			$skip_message = 'All theme files were skipped.',
-			$success_message = "Created '$theme_dir'."
-		);
+		$skip_message    = 'All theme files were skipped.';
+		$success_message = "Created '$theme_dir'.";
+		$this->log_whether_files_written( $files_written, $skip_message, $success_message );
 
 		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'activate' ) ) {
 			WP_CLI::run_command( array( 'theme', 'activate', $theme_slug ) );
@@ -690,11 +684,9 @@ class Scaffold_Command extends WP_CLI_Command {
 			"$plugin_dir/.editorconfig" => file_get_contents( self::get_template_path( '.editorconfig' ) ),
 		), $force );
 
-		$this->log_whether_files_written(
-			$files_written,
-			$skip_message = 'All plugin files were skipped.',
-			$success_message = 'Created plugin files.'
-		);
+		$skip_message    = 'All plugin files were skipped.';
+		$success_message = 'Created plugin files.';
+		$this->log_whether_files_written( $files_written, $skip_message, $success_message );
 
 		if ( ! \WP_CLI\Utils\get_flag_value( $assoc_args, 'skip-tests' ) ) {
 			$ci = empty( $assoc_args['ci'] ) ? '' : $assoc_args['ci'];
@@ -920,11 +912,10 @@ class Scaffold_Command extends WP_CLI_Command {
 				}
 			}
 		}
-		$this->log_whether_files_written(
-			$files_written,
-			$skip_message = 'All test files were skipped.',
-			$success_message = 'Created test files.'
-		);
+
+		$skip_message    = 'All test files were skipped.';
+		$success_message = 'Created test files.';
+		$this->log_whether_files_written( $files_written, $skip_message, $success_message );
 	}
 
 	/**


### PR DESCRIPTION
When calling a function, it is nonsensical to assign the value of the parameter being passed to a variable _within the function call_, especially if that variable isn't used anywhere else.

This is just not a thing in PHP.

Looking at the code, it looks like this was done to document what the parameters meant.
With that in mind, I've kept the variable assignments, but moved them out of the function call.

Alternatively, the meaning of the passed parameters could just be documented via inline trailing `// [TYPE] message.` comments.

<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->
