### PR TITLE
PHPCS: fix up the code base [3] - strict comparisons (second try)

### DIFF
--- a/src/Scaffold_Command.php
+++ b/src/Scaffold_Command.php
@@ -430,7 +430,7 @@ class Scaffold_Command extends WP_CLI_Command {
 		}
 
 		$response_code = wp_remote_retrieve_response_code( $response );
-		if ( 200 != $response_code ) {
+		if ( 200 !== (int) $response_code ) {
 			WP_CLI::error( "Couldn't create theme (received {$response_code} response)." );
 		}
 


### PR DESCRIPTION
Fixes relate to the following rules:
* Use strict comparisons.

This fix was previously merged already via #209, but this got undone by the master-merge-back in #207.