### PR TITLE
Switch test prep feature from global PHPUnit to local PHPUnit

### DIFF
--- a/features/install-wp-tests.feature
+++ b/features/install-wp-tests.feature
@@ -73,7 +73,7 @@ Feature: Scaffold install-wp-tests.sh tests
       wp_cli_test_scaffold
       """
 
-    When I run `WP_TESTS_DIR=/tmp/behat-wordpress-tests-lib phpunit -c {PLUGIN_DIR}/hello-world/phpunit.xml.dist`
+    When I run `WP_TESTS_DIR=/tmp/behat-wordpress-tests-lib vendor/bin/phpunit -c {PLUGIN_DIR}/hello-world/phpunit.xml.dist`
     Then the return code should be 0
 
   @require-php-5.6
@@ -148,7 +148,7 @@ Feature: Scaffold install-wp-tests.sh tests
       wp_cli_test_scaffold
       """
 
-    When I run `WP_TESTS_DIR=/tmp/behat-wordpress-tests-lib phpunit -c {PLUGIN_DIR}/hello-world/phpunit.xml.dist`
+    When I run `WP_TESTS_DIR=/tmp/behat-wordpress-tests-lib vendor/bin/phpunit -c {PLUGIN_DIR}/hello-world/phpunit.xml.dist`
     Then the return code should be 0
 
   Scenario: Install WordPress 3.7 and phpunit will not run


### PR DESCRIPTION
This should fix the issue that PHPUnit 4.8 is used, even in PHP 7.2, throwing notices...