### PR TITLE
Required PHP version header

### DIFF
--- a/templates/plugin-readme.mustache
+++ b/templates/plugin-readme.mustache
@@ -4,6 +4,7 @@ Donate link: https://example.com/
 Tags: comments, spam
 Requires at least: 4.5
 Tested up to: {{plugin_tested_up_to}}
+Requires PHP: 5.6
 Stable tag: 0.1.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
Add minimum required PHP version header in plugin's readme file.

https://make.wordpress.org/plugins/2017/08/29/minimum-php-version-requirement/