### PR TITLE
Remove WordPress.VIP ruleset reference

### DIFF
--- a/templates/.phpcs.xml.dist
+++ b/templates/.phpcs.xml.dist
@@ -26,9 +26,7 @@
 	<!-- https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards -->
 	<!-- https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties -->
 	<config name="minimum_supported_wp_version" value="4.6"/>
-	<rule ref="WordPress">
-		<exclude name="WordPress.VIP"/>
-	</rule>
+	<rule ref="WordPress"/>
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
 		<properties>
 			<!-- Value: replace the function, class, and variable prefixes used. Separate multiple prefixes with a comma. -->


### PR DESCRIPTION
As now [WordPress VIP rules](https://github.com/Automattic/VIP-Coding-Standards) reside outside [WordPress Coding Standards](https://github.com/WordPress/WordPress-Coding-Standards), this PR removes its reference from the `.phpcs.xml.dist` template.

cc @jrfnl 