### PR TITLE
Fixed 228 - init script can be used repeatedly

### DIFF
--- a/features/install-wp-tests.feature
+++ b/features/install-wp-tests.feature
@@ -82,9 +82,13 @@ Feature: Scaffold install-wp-tests.sh tests
 
     When I try `WP_TESTS_DIR=/tmp/behat-wordpress-tests-lib WP_CORE_DIR=/tmp/behat-wordpress /usr/bin/env bash {PLUGIN_DIR}/hello-world/bin/install-wp-tests.sh wp_cli_test_scaffold wp_cli_test password1 localhost latest < affirmative-response`
     Then the return code should be 0
+    And STDERR should contain:
+      """
+      Reinstalling
+      """
     And STDOUT should contain:
       """
-      Recreated the database
+      wp_cli_test_scaffold
       """
 
   @require-php-5.6

--- a/features/install-wp-tests.feature
+++ b/features/install-wp-tests.feature
@@ -103,7 +103,7 @@ Feature: Scaffold install-wp-tests.sh tests
       """
     And STDOUT should contain:
       """
-      Leaving the existing database
+      Leaving the existing database wp_cli_test_scaffold in place
       """
 
   @require-php-5.6

--- a/features/install-wp-tests.feature
+++ b/features/install-wp-tests.feature
@@ -17,6 +17,10 @@ Feature: Scaffold install-wp-tests.sh tests
   @require-php-5.6
   Scenario: Install latest version of WordPress
     Given a WP install
+    And a affirmative-response file:
+    """
+    Y
+    """
     And I run `wp plugin path`
     And save STDOUT as {PLUGIN_DIR}
     And I run `wp scaffold plugin hello-world`
@@ -75,6 +79,13 @@ Feature: Scaffold install-wp-tests.sh tests
 
     When I run `WP_TESTS_DIR=/tmp/behat-wordpress-tests-lib phpunit -c {PLUGIN_DIR}/hello-world/phpunit.xml.dist`
     Then the return code should be 0
+
+    When I try `WP_TESTS_DIR=/tmp/behat-wordpress-tests-lib WP_CORE_DIR=/tmp/behat-wordpress /usr/bin/env bash {PLUGIN_DIR}/hello-world/bin/install-wp-tests.sh wp_cli_test_scaffold wp_cli_test password1 localhost latest < affirmative-response`
+    Then the return code should be 0
+    And STDOUT should contain:
+      """
+      Recreated the database
+      """
 
   @require-php-5.6
   Scenario: Install WordPress from trunk

--- a/features/install-wp-tests.feature
+++ b/features/install-wp-tests.feature
@@ -21,6 +21,10 @@ Feature: Scaffold install-wp-tests.sh tests
     """
     Y
     """
+    And a negative-response file:
+    """
+    No
+    """
     And I run `wp plugin path`
     And save STDOUT as {PLUGIN_DIR}
     And I run `wp scaffold plugin hello-world`
@@ -89,6 +93,17 @@ Feature: Scaffold install-wp-tests.sh tests
     And STDOUT should contain:
       """
       wp_cli_test_scaffold
+      """
+
+    When I try `WP_TESTS_DIR=/tmp/behat-wordpress-tests-lib WP_CORE_DIR=/tmp/behat-wordpress /usr/bin/env bash {PLUGIN_DIR}/hello-world/bin/install-wp-tests.sh wp_cli_test_scaffold wp_cli_test password1 localhost latest < negative-response`
+    Then the return code should be 0
+    And STDERR should contain:
+      """
+      Reinstalling
+      """
+    And STDOUT should contain:
+      """
+      Leaving the existing database
       """
 
   @require-php-5.6

--- a/features/install-wp-tests.feature
+++ b/features/install-wp-tests.feature
@@ -92,7 +92,7 @@ Feature: Scaffold install-wp-tests.sh tests
       """
     And STDOUT should contain:
       """
-      Recreated the database wp_cli_test_scaffold
+      Recreated the database (wp_cli_test_scaffold)
       """
 
     When I try `WP_TESTS_DIR=/tmp/behat-wordpress-tests-lib WP_CORE_DIR=/tmp/behat-wordpress /usr/bin/env bash {PLUGIN_DIR}/hello-world/bin/install-wp-tests.sh wp_cli_test_scaffold wp_cli_test password1 localhost latest < negative-response`
@@ -103,7 +103,7 @@ Feature: Scaffold install-wp-tests.sh tests
       """
     And STDOUT should contain:
       """
-      Leaving the existing database wp_cli_test_scaffold in place
+      Leaving the existing database (wp_cli_test_scaffold) in place
       """
 
   @require-php-5.6

--- a/features/install-wp-tests.feature
+++ b/features/install-wp-tests.feature
@@ -92,7 +92,7 @@ Feature: Scaffold install-wp-tests.sh tests
       """
     And STDOUT should contain:
       """
-      wp_cli_test_scaffold
+      Recreated the database wp_cli_test_scaffold
       """
 
     When I try `WP_TESTS_DIR=/tmp/behat-wordpress-tests-lib WP_CORE_DIR=/tmp/behat-wordpress /usr/bin/env bash {PLUGIN_DIR}/hello-world/bin/install-wp-tests.sh wp_cli_test_scaffold wp_cli_test password1 localhost latest < negative-response`

--- a/templates/install-wp-tests.sh
+++ b/templates/install-wp-tests.sh
@@ -147,7 +147,7 @@ install_db() {
 	fi
 
 	# create database
-	if [ $(mysql -e --user="$DB_USER" --password="$DB_PASS" 'show databases;' | grep ^$DB_NAME$) ]
+	if [ $(mysql -u "$DB_USER" -p"$DB_PASS" -e 'show databases;' | grep ^$DB_NAME$) ]
 	then
 		echo "Reinstalling will delete the existing test database ($DB_NAME)"
 		read -p 'Are you sure you want to proceed? [y/N]: ' DELETE_EXISTING_DB
@@ -156,6 +156,7 @@ install_db() {
 		then
 			mysqladmin drop $DB_NAME -f --user="$DB_USER" --password="$DB_PASS"$EXTRA > /dev/null 2>&1
 			mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA
+			echo "Recreated the database ($DB_NAME)."
 		else
 			echo "Leaving the existing database ($DB_NAME) in place."
 		fi

--- a/templates/install-wp-tests.sh
+++ b/templates/install-wp-tests.sh
@@ -147,6 +147,7 @@ install_db() {
 	fi
 
 	# create database
+	mysqladmin drop $DB_NAME -f --user="$DB_USER" --password="$DB_PASS"$EXTRA > /dev/null 2>&1
 	mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA
 }
 

--- a/templates/install-wp-tests.sh
+++ b/templates/install-wp-tests.sh
@@ -147,8 +147,19 @@ install_db() {
 	fi
 
 	# create database
-	mysqladmin drop $DB_NAME -f --user="$DB_USER" --password="$DB_PASS"$EXTRA > /dev/null 2>&1
-	mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA
+	if [ $(mysql -e 'show databases;' | grep ^$DB_NAME$) ]
+	then
+		echo "Reinstalling will delete the existing test database ($DB_NAME)"
+		read -p 'Are you sure you want to proceed? [No/Yes]: ' DELETE_EXISTING_DB
+		# Matches on Y, y, Ye, YE, ye, yE, Ys, YS, ys, yS, Yes, yes, YEs, YES, yES, yeS, yEs, yeS, and maybe others
+		if [[ $DELETE_EXISTING_DB =~ [yY]+[eEsS]* ]]
+		then
+			mysqladmin drop $DB_NAME -f --user="$DB_USER" --password="$DB_PASS"$EXTRA > /dev/null 2>&1
+			mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA
+		else
+			echo "Leaving the existing database ($DB_NAME) in place."
+		fi
+	fi
 }
 
 install_wp

--- a/templates/install-wp-tests.sh
+++ b/templates/install-wp-tests.sh
@@ -151,14 +151,15 @@ install_db() {
 	then
 		echo "Reinstalling will delete the existing test database ($DB_NAME)"
 		read -p 'Are you sure you want to proceed? [No/Yes]: ' DELETE_EXISTING_DB
-		# Matches on Y, y, Ye, YE, ye, yE, Ys, YS, ys, yS, Yes, yes, YEs, YES, yES, yeS, yEs, yeS, and maybe others
-		if [[ $DELETE_EXISTING_DB =~ [yY]+[eEsS]* ]]
+		shopt -s nocasematch
+		if [[ $DELETE_EXISTING_DB =~ ^(y|yes)$ ]]
 		then
 			mysqladmin drop $DB_NAME -f --user="$DB_USER" --password="$DB_PASS"$EXTRA > /dev/null 2>&1
 			mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA
 		else
 			echo "Leaving the existing database ($DB_NAME) in place."
 		fi
+		shopt -u nocasematch
 	fi
 }
 

--- a/templates/install-wp-tests.sh
+++ b/templates/install-wp-tests.sh
@@ -124,6 +124,23 @@ install_test_suite() {
 
 }
 
+recreate_db() {
+	shopt -s nocasematch
+	if [[ $1 =~ ^(y|yes)$ ]]
+	then
+		mysqladmin drop $DB_NAME -f --user="$DB_USER" --password="$DB_PASS"$EXTRA
+		create_db
+		echo "Recreated the database ($DB_NAME)."
+	else
+		echo "Leaving the existing database ($DB_NAME) in place."
+	fi
+	shopt -u nocasematch
+}
+
+create_db() {
+	mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA
+}
+
 install_db() {
 
 	if [ ${SKIP_DB_CREATE} = "true" ]; then
@@ -151,18 +168,9 @@ install_db() {
 	then
 		echo "Reinstalling will delete the existing test database ($DB_NAME)"
 		read -p 'Are you sure you want to proceed? [y/N]: ' DELETE_EXISTING_DB
-		shopt -s nocasematch
-		if [[ $DELETE_EXISTING_DB =~ ^(y|yes)$ ]]
-		then
-			mysqladmin drop $DB_NAME -f --user="$DB_USER" --password="$DB_PASS"$EXTRA > /dev/null 2>&1
-			mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA
-			echo "Recreated the database ($DB_NAME)."
-		else
-			echo "Leaving the existing database ($DB_NAME) in place."
-		fi
-		shopt -u nocasematch
+		recreate_db $DELETE_EXISTING_DB
 	else
-		mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA
+		create_db
 	fi
 }
 

--- a/templates/install-wp-tests.sh
+++ b/templates/install-wp-tests.sh
@@ -147,10 +147,10 @@ install_db() {
 	fi
 
 	# create database
-	if [ $(mysql -e 'show databases;' | grep ^$DB_NAME$) ]
+	if [ $(mysql -e --user="$DB_USER" --password="$DB_PASS" 'show databases;' | grep ^$DB_NAME$) ]
 	then
 		echo "Reinstalling will delete the existing test database ($DB_NAME)"
-		read -p 'Are you sure you want to proceed? [No/Yes]: ' DELETE_EXISTING_DB
+		read -p 'Are you sure you want to proceed? [y/N]: ' DELETE_EXISTING_DB
 		shopt -s nocasematch
 		if [[ $DELETE_EXISTING_DB =~ ^(y|yes)$ ]]
 		then
@@ -160,6 +160,8 @@ install_db() {
 			echo "Leaving the existing database ($DB_NAME) in place."
 		fi
 		shopt -u nocasematch
+	else
+		mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA
 	fi
 }
 


### PR DESCRIPTION
Fixed in issue in which the init script would fail if the database was already created. See #228 for details. I'm more than happy to write tests or whatever else is needed to get this in.