### PR TITLE
Fix Travis CI `sudo` warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+os: linux
 dist: xenial
 
 language: php


### PR DESCRIPTION
Travis currently shows a warning that the configuration option `sudo` has been deprecated.

As there's another information (not a warning yet) that the configuration argument `os` is missing and defaults to `linux`, this PR replace `sudo: false` with `os: linux`.