### PR TITLE
Use longer option names in `install_db()` to avoid stalling CIs

### DIFF
--- a/templates/install-wp-tests.sh
+++ b/templates/install-wp-tests.sh
@@ -165,7 +165,7 @@ install_db() {
 	fi
 
 	# create database
-	if [ $(mysql -u "$DB_USER" -p"$DB_PASS" -e 'show databases;' | grep ^$DB_NAME$) ]
+	if [ $(mysql --user="$DB_USER" --password="$DB_PASS" --execute='show databases;' | grep ^$DB_NAME$) ]
 	then
 		echo "Reinstalling will delete the existing test database ($DB_NAME)"
 		read -p 'Are you sure you want to proceed? [y/N]: ' DELETE_EXISTING_DB


### PR DESCRIPTION
Since some platforms (such as Travis CI) use empty passwords for the database user, passing an empty string for `$DB_PASS` can result in a TTY prompt, e.g.:

```sh
$ DB_USER=someuser DB_PASS="" mysql -u "$DB_USER" -p"$DB_PASS" -e 'show databases;'
Enter password:
```

In a CI environment, [this can cause the entire pipeline to hang until cancelled](https://travis-ci.org/github/nexcess/woocommerce-limit-orders/jobs/667345104#L290).

This PR rewrites the call to use the longer option names (`--user`, `--password`, and `--execute`) to prevent empty passwords from being interpreted as "please ask me to provide my password in an interactive prompt."
