### PR TITLE
Enforce PHP 7.4 compatibility in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 dist: xenial
 
 language: php
-php: 7.3
+php: 7.4
 
 notifications:
   email:
@@ -54,7 +54,7 @@ jobs:
         - composer phpcs
       env: BUILD=sniff
     - stage: test
-      php: 7.4snapshot
+      php: 7.4
       env: WP_VERSION=latest
     - stage: test
       php: 7.3
@@ -81,7 +81,3 @@ jobs:
       dist: precise
       php: 5.4
       env: WP_VERSION=5.1
-  allow_failures:
-    - stage: test
-      php: 7.4snapshot
-      env: WP_VERSION=latest


### PR DESCRIPTION
This PR changes the Travis CI configuration to use PHP 7.4 for all main tests nd switches the PHP 7.4 tests from allowing failures to failing the build on errors.

It will also include any fixes that might be required to get the tests to pass.