### PR TITLE
Bump Travis CI OS from `trusty` to `xenial`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ dist: xenial
 language: php
 php: 7.3
 
+services:
+  - mysql
+
 notifications:
   email:
     on_success: never

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,6 +77,7 @@ jobs:
     - stage: test
       php: 5.6
       env: WP_VERSION=3.7.11
+      dist: trusty
     - stage: test
       php: 5.6
       env: WP_VERSION=trunk

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": "^5.4 || ^7.0",
-        "wp-cli/wp-cli": "^2"
+        "wp-cli/wp-cli": "dev-master"
     },
     "require-dev": {
         "wp-cli/extension-command": "^1.2 || ^2",

--- a/features/scaffold.feature
+++ b/features/scaffold.feature
@@ -335,7 +335,7 @@ Feature: WordPress code scaffolding
       """
     And the return code should be 1
 
-  @require-php-5.6
+  @require-php-5.6 @require-wp-4.6
   Scenario: Scaffold starter code for a theme
     Given a WP install
     Given I run `wp theme path`
@@ -350,7 +350,7 @@ Feature: WordPress code scaffolding
     And the {THEME_DIR}/starter-theme/style.css file should exist
     And the {THEME_DIR}/starter-theme/.editorconfig file should exist
 
-  @require-php-5.6
+  @require-php-5.6 @require-wp-4.6
   Scenario: Scaffold starter code for a theme with sass
     Given a WP install
     Given I run `wp theme path`
@@ -364,7 +364,7 @@ Feature: WordPress code scaffolding
       """
     And the {THEME_DIR}/starter-theme/sass directory should exist
 
-  @require-php-5.6
+  @require-php-5.6 @require-wp-4.6
   Scenario: Scaffold starter code for a WooCommerce theme
     Given a WP install
     Given I run `wp theme path`
@@ -379,7 +379,7 @@ Feature: WordPress code scaffolding
     And the {THEME_DIR}/starter-theme/woocommerce.css file should exist
     And the {THEME_DIR}/starter-theme/inc/woocommerce.php file should exist
 
-  @require-php-5.6
+  @require-php-5.6 @require-wp-4.6
   Scenario: Scaffold starter code for a theme and activate it
     Given a WP install
     # Allow for warnings to be generated due to https://github.com/wp-cli/scaffold-command/issues/181
@@ -506,7 +506,7 @@ Feature: WordPress code scaffolding
       Success: Network enabled the 'Starter-theme' theme.
       """
 
-  @require-php-5.6
+  @require-php-5.6 @require-wp-4.6
   Scenario: Scaffold starter code for a theme, but can't unzip theme files
     Given a WP install
     And a misconfigured WP_CONTENT_DIR constant directory


### PR DESCRIPTION
This PR changes the Travis CI configuration to use the `xenial` Ubuntu distribution instead of the `trusty` one by default.