### PR TITLE
Update plugin/theme test scaffolding

### DIFF
--- a/features/scaffold-plugin-tests.feature
+++ b/features/scaffold-plugin-tests.feature
@@ -75,8 +75,6 @@ Feature: Scaffold plugin unit tests
             env: WP_VERSION=trunk
           - php: 5.6
             env: WP_TRAVISCI=phpcs
-          - php: 5.3
-            env: WP_VERSION=latest
       """
 
     When I run `wp eval "if ( is_executable( '{PLUGIN_DIR}/hello-world/bin/install-wp-tests.sh' ) ) { echo 'executable'; } else { exit( 1 ); }"`

--- a/features/scaffold-theme-tests.feature
+++ b/features/scaffold-theme-tests.feature
@@ -71,8 +71,6 @@ Feature: Scaffold theme unit tests
             env: WP_VERSION=trunk
           - php: 5.6
             env: WP_TRAVISCI=phpcs
-          - php: 5.3
-            env: WP_VERSION=latest
       """
 
     When I run `wp eval "if ( is_executable( '{THEME_DIR}/p2child/bin/install-wp-tests.sh' ) ) { echo 'executable'; } else { exit( 1 ); }"`

--- a/features/scaffold.feature
+++ b/features/scaffold.feature
@@ -231,7 +231,7 @@ Feature: WordPress code scaffolding
       """
     And the {PLUGIN_DIR}/hello-world/.phpcs.xml.dist file should contain:
       """
-      	<config name="testVersion" value="5.3-"/>
+      	<config name="testVersion" value="5.6-"/>
       """
     And the {PLUGIN_DIR}/hello-world/hello-world.php file should contain:
       """
@@ -492,8 +492,6 @@ Feature: WordPress code scaffolding
             env: WP_VERSION=trunk
           - php: 5.6
             env: WP_TRAVISCI=phpcs
-          - php: 5.3
-            env: WP_VERSION=latest
       """
 
   @require-php-5.6 @require-wp-4.6

--- a/templates/.phpcs.xml.dist
+++ b/templates/.phpcs.xml.dist
@@ -18,7 +18,7 @@
 
 	<!-- Rules: Check PHP version compatibility -->
 	<!-- https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions -->
-	<config name="testVersion" value="5.3-"/>
+	<config name="testVersion" value="5.6-"/>
 	<!-- https://github.com/PHPCompatibility/PHPCompatibilityWP -->
 	<rule ref="PHPCompatibilityWP"/>
 
@@ -26,9 +26,7 @@
 	<!-- https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards -->
 	<!-- https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties -->
 	<config name="minimum_supported_wp_version" value="4.6"/>
-	<rule ref="WordPress">
-		<exclude name="WordPress.VIP"/>
-	</rule>
+	<rule ref="WordPress"/>
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
 		<properties>
 			<!-- Value: replace the function, class, and variable prefixes used. Separate multiple prefixes with a comma. -->

--- a/templates/plugin-travis.mustache
+++ b/templates/plugin-travis.mustache
@@ -30,9 +30,6 @@ matrix:
     {{/wp_versions_to_test}}
     - php: 5.6
       env: WP_TRAVISCI=phpcs
-    - php: 5.3
-      env: WP_VERSION=latest
-      dist: precise
 
 before_script:
   - export PATH="$HOME/.composer/vendor/bin:$PATH"
@@ -50,7 +47,10 @@ before_script:
   - |
     if [[ "$WP_TRAVISCI" == "phpcs" ]] ; then
       composer global require wp-coding-standards/wpcs
-      phpcs --config-set installed_paths $HOME/.composer/vendor/wp-coding-standards/wpcs
+      composer global require phpcompatibility/php-compatibility
+      composer global require phpcompatibility/phpcompatibility-paragonie
+      composer global require phpcompatibility/phpcompatibility-wp
+      phpcs --config-set installed_paths $HOME/.composer/vendor/wp-coding-standards/wpcs,$HOME/.composer/vendor/phpcompatibility/php-compatibility,$HOME/.composer/vendor/phpcompatibility/phpcompatibility-paragonie,$HOME/.composer/vendor/phpcompatibility/phpcompatibility-wp
     fi
 
 script:


### PR DESCRIPTION
- Removes tests for PHP 5.3 to adapt to WP minimum of PHP 5.6+
- Add PHPCompatibility rule sets
- Adapt tests

All credits go to @whoisnegrello, whose original PR #258 I accidentally erased.