### PR TITLE
Add PHP version 7.3, 7.4 into matrix on Travis CI

### DIFF
--- a/features/scaffold-plugin-tests.feature
+++ b/features/scaffold-plugin-tests.feature
@@ -61,6 +61,10 @@ Feature: Scaffold plugin unit tests
       """
       matrix:
         include:
+          - php: 7.4
+            env: WP_VERSION=latest
+          - php: 7.3
+            env: WP_VERSION=latest
           - php: 7.2
             env: WP_VERSION=latest
           - php: 7.1

--- a/features/scaffold-theme-tests.feature
+++ b/features/scaffold-theme-tests.feature
@@ -59,6 +59,10 @@ Feature: Scaffold theme unit tests
       """
       matrix:
         include:
+          - php: 7.4
+            env: WP_VERSION=latest
+          - php: 7.3
+            env: WP_VERSION=latest
           - php: 7.2
             env: WP_VERSION=latest
           - php: 7.1

--- a/features/scaffold.feature
+++ b/features/scaffold.feature
@@ -478,6 +478,10 @@ Feature: WordPress code scaffolding
       """
       matrix:
         include:
+          - php: 7.4
+            env: WP_VERSION=latest
+          - php: 7.3
+            env: WP_VERSION=latest
           - php: 7.2
             env: WP_VERSION=latest
           - php: 7.1

--- a/templates/plugin-travis.mustache
+++ b/templates/plugin-travis.mustache
@@ -18,6 +18,10 @@ cache:
 
 matrix:
   include:
+    - php: 7.4
+      env: WP_VERSION=latest
+    - php: 7.3
+      env: WP_VERSION=latest
     - php: 7.2
       env: WP_VERSION=latest
     - php: 7.1


### PR DESCRIPTION
Since current PHP recommended version is 7.3+.
@see https://wordpress.org/support/article/requirements/
