### PR TITLE
Fix bug that can't init non default host DB

### DIFF
--- a/templates/install-wp-tests.sh
+++ b/templates/install-wp-tests.sh
@@ -165,7 +165,7 @@ install_db() {
 	fi
 
 	# create database
-	if [ $(mysql --user="$DB_USER" --password="$DB_PASS" --execute='show databases;' | grep ^$DB_NAME$) ]
+	if [ $(mysql --user="$DB_USER" --password="$DB_PASS"$EXTRA --execute='show databases;' | grep ^$DB_NAME$) ]
 	then
 		echo "Reinstalling will delete the existing test database ($DB_NAME)"
 		read -p 'Are you sure you want to proceed? [y/N]: ' DELETE_EXISTING_DB


### PR DESCRIPTION
#249 forget to add $EXTRA parameters when check existing database.
Therefore, when we use install-wp-tests.sh to non default host DB like other Docker container,
we got error:

```console
ERROR 2002 (HY000): Can't connect to local MySQL server through socket '/var/run/mysqld/mysqld.sock' (2)
```