### PR TITLE
GitHub workflow files should be ignored on build

### DIFF
--- a/templates/plugin-distignore.mustache
+++ b/templates/plugin-distignore.mustache
@@ -7,6 +7,7 @@
 .eslintrc
 .git
 .gitignore
+.github
 .gitlab-ci.yml
 .travis.yml
 .DS_Store


### PR DESCRIPTION
`.github` workflow files is not necessary for distribution build.