### PR TITLE
Add backup files ending with tilde to .distignore

### DIFF
--- a/templates/plugin-distignore.mustache
+++ b/templates/plugin-distignore.mustache
@@ -11,6 +11,7 @@
 .gitlab-ci.yml
 .travis.yml
 .DS_Store
+.*~
 Thumbs.db
 behat.yml
 bitbucket-pipelines.yml


### PR DESCRIPTION
Editors like Vim and Gedit will create backup copies of a file. A file named `foobar` may get a backup copy called `.foobar~`, with the prefix of a dot and the suffix of a tilde.

This pull request adds that pattern to `.distignore`.