### PR TITLE
GH Actions: don't run the "update readme" workflow on forks

### DIFF
--- a/.github/workflows/regenerate-readme.yml
+++ b/.github/workflows/regenerate-readme.yml
@@ -14,7 +14,7 @@ jobs:
   regenerate-readme: #----------------------------------------------------------
     name: Regenerate README.md file
     runs-on: ubuntu-latest
-    if: ${{ ! contains(fromJson('[".github", "wp-cli", "wp-cli-bundle", "wp-super-cache-cli", "php-cli-tools", "wp-config-transformer"]'), github.event.repository.name) }}
+    if: ${{ github.repository == 'wp-cli/scaffold-command' && ! contains(fromJson('[".github", "wp-cli", "wp-cli-bundle", "wp-super-cache-cli", "php-cli-tools", "wp-config-transformer"]'), github.event.repository.name) }}
     steps:
       - name: Check out source code
         uses: actions/checkout@v2


### PR DESCRIPTION
The `regenerate-readme` workflow to automatically update the readme and send in a PR for the changes is run on pushes to `master`, but that includes pushes to `master` in forks.

Generally speaking, those kind of PRs do not belong in forks, so, I'd like to propose making this small change, which _should_ prevent this workflow from being run on forks.