### PR TITLE
Fix testing on WP trunk

### DIFF
--- a/features/install-wp-tests.feature
+++ b/features/install-wp-tests.feature
@@ -219,7 +219,7 @@ Feature: Scaffold install-wp-tests.sh tests
     Then the return code should be 1
     And STDOUT should contain:
       """
-      The scaffolded tests cannot currently be run on PHP 8.0+. See https://github.com/wp-cli/scaffold-command/issues/285
+      Looks like you're using PHPUnit 9.5.8. WordPress requires at least PHPUnit 5.4 and is currently only compatible with PHPUnit up to 7.x.
       """
 
     When I try `WP_TESTS_DIR={RUN_DIR}/wordpress-tests-lib WP_CORE_DIR={RUN_DIR}/wordpress /usr/bin/env bash {PLUGIN_DIR}/hello-world/bin/install-wp-tests.sh wp_cli_test_scaffold {DB_USER} {DB_PASSWORD} {DB_HOST} latest < affirmative-response`

--- a/features/install-wp-tests.feature
+++ b/features/install-wp-tests.feature
@@ -50,7 +50,6 @@ Feature: Scaffold install-wp-tests.sh tests
     And I run `wp plugin path`
     And save STDOUT as {PLUGIN_DIR}
     And I run `wp scaffold plugin hello-world`
-    # TODO: Hardcoded for GHA, needs to be made more flexible for local setups.
     # This throws a warning for the password provided via command line.
     And I try `mysql -u{DB_USER} -p{DB_PASSWORD} -h{MYSQL_HOST} -P{MYSQL_PORT} --protocol=tcp -e "DROP DATABASE IF EXISTS wp_cli_test_scaffold"`
     And I try `rm -fr /tmp/behat-wordpress-tests-lib`
@@ -98,7 +97,6 @@ Feature: Scaffold install-wp-tests.sh tests
       install_test_suite
       """
 
-    # TODO: Hardcoded for GHA, needs to be made more flexible for local setups.
     # This throws a warning for the password provided via command line.
     When I try `mysql -u{DB_USER} -p{DB_PASSWORD} -h{MYSQL_HOST} -P{MYSQL_PORT} --protocol=tcp -e "SHOW DATABASES"`
     And STDOUT should contain:
@@ -167,7 +165,6 @@ Feature: Scaffold install-wp-tests.sh tests
     And I run `wp plugin path`
     And save STDOUT as {PLUGIN_DIR}
     And I run `wp scaffold plugin hello-world`
-    # TODO: Hardcoded for GHA, needs to be made more flexible for local setups.
     # This throws a warning for the password provided via command line.
     And I try `mysql -u{DB_USER} -p{DB_PASSWORD} -h{MYSQL_HOST} -P{MYSQL_PORT} --protocol=tcp -e "DROP DATABASE IF EXISTS wp_cli_test_scaffold"`
     And I try `rm -fr /tmp/behat-wordpress-tests-lib`
@@ -215,7 +212,6 @@ Feature: Scaffold install-wp-tests.sh tests
       install_test_suite
       """
 
-    # TODO: Hardcoded for GHA, needs to be made more flexible for local setups.
     # This throws a warning for the password provided via command line.
     When I try `mysql -u{DB_USER} -p{DB_PASSWORD} -h{MYSQL_HOST} -P{MYSQL_PORT} --protocol=tcp -e "SHOW DATABASES"`
     And STDOUT should contain:
@@ -280,7 +276,6 @@ Feature: Scaffold install-wp-tests.sh tests
     And I run `wp plugin path`
     And save STDOUT as {PLUGIN_DIR}
     And I run `wp scaffold plugin hello-world`
-    # TODO: Hardcoded for GHA, needs to be made more flexible for local setups.
     # This throws a warning for the password provided via command line.
     And I try `mysql -u{DB_USER} -p{DB_PASSWORD} -h{MYSQL_HOST} -P{MYSQL_PORT} --protocol=tcp -e "DROP DATABASE IF EXISTS wp_cli_test_scaffold"`
     And I try `rm -fr /tmp/behat-wordpress-tests-lib`
@@ -341,7 +336,6 @@ Feature: Scaffold install-wp-tests.sh tests
       install_test_suite
       """
 
-    # TODO: Hardcoded for GHA, needs to be made more flexible for local setups.
     # This throws a warning for the password provided via command line.
     When I try `mysql -u{DB_USER} -p{DB_PASSWORD} -h{MYSQL_HOST} -P{MYSQL_PORT} --protocol=tcp -e "SHOW DATABASES"`
     And STDOUT should contain:
@@ -380,7 +374,6 @@ Feature: Scaffold install-wp-tests.sh tests
     And I run `wp plugin path`
     And save STDOUT as {PLUGIN_DIR}
     And I run `wp scaffold plugin hello-world`
-    # TODO: Hardcoded for GHA, needs to be made more flexible for local setups.
     # This throws a warning for the password provided via command line.
     And I try `mysql -u{DB_USER} -p{DB_PASSWORD} -h{MYSQL_HOST} -P{MYSQL_PORT} --protocol=tcp -e "DROP DATABASE IF EXISTS wp_cli_test_scaffold"`
     And I try `rm -fr /tmp/behat-wordpress-tests-lib`
@@ -441,7 +434,6 @@ Feature: Scaffold install-wp-tests.sh tests
       install_test_suite
       """
 
-    # TODO: Hardcoded for GHA, needs to be made more flexible for local setups.
     # This throws a warning for the password provided via command line.
     When I try `mysql -u{DB_USER} -p{DB_PASSWORD} -h{MYSQL_HOST} -P{MYSQL_PORT} --protocol=tcp -e "SHOW DATABASES"`
     And STDOUT should contain:
@@ -461,7 +453,6 @@ Feature: Scaffold install-wp-tests.sh tests
     And I run `wp plugin path`
     And save STDOUT as {PLUGIN_DIR}
     And I run `wp scaffold plugin hello-world`
-    # TODO: Hardcoded for GHA, needs to be made more flexible for local setups.
     # This throws a warning for the password provided via command line.
     And I try `mysql -u{DB_USER} -p{DB_PASSWORD} -h{MYSQL_HOST} -P{MYSQL_PORT} --protocol=tcp -e "DROP DATABASE IF EXISTS wp_cli_test_scaffold"`
     And I try `rm -fr /tmp/behat-wordpress-tests-lib`
@@ -512,7 +503,6 @@ Feature: Scaffold install-wp-tests.sh tests
       install_test_suite
       """
 
-    # TODO: Hardcoded for GHA, needs to be made more flexible for local setups.
     # This throws a warning for the password provided via command line.
     When I try `mysql -u{DB_USER} -p{DB_PASSWORD} -h{MYSQL_HOST} -P{MYSQL_PORT} --protocol=tcp -e "SHOW DATABASES"`
     And STDOUT should contain:

--- a/features/install-wp-tests.feature
+++ b/features/install-wp-tests.feature
@@ -52,24 +52,22 @@ Feature: Scaffold install-wp-tests.sh tests
     And I run `wp scaffold plugin hello-world`
     # This throws a warning for the password provided via command line.
     And I try `mysql -u{DB_USER} -p{DB_PASSWORD} -h{MYSQL_HOST} -P{MYSQL_PORT} --protocol=tcp -e "DROP DATABASE IF EXISTS wp_cli_test_scaffold"`
-    And I try `rm -fr /tmp/behat-wordpress-tests-lib`
-    And I try `rm -fr /tmp/behat-wordpress`
 
-    When I try `WP_TESTS_DIR=/tmp/behat-wordpress-tests-lib WP_CORE_DIR=/tmp/behat-wordpress /usr/bin/env bash {PLUGIN_DIR}/hello-world/bin/install-wp-tests.sh wp_cli_test_scaffold {DB_USER} {DB_PASSWORD} {DB_HOST} latest`
+    When I try `WP_TESTS_DIR={RUN_DIR}/wordpress-tests-lib WP_CORE_DIR={RUN_DIR}/wordpress /usr/bin/env bash {PLUGIN_DIR}/hello-world/bin/install-wp-tests.sh wp_cli_test_scaffold {DB_USER} {DB_PASSWORD} {DB_HOST} latest`
     Then the return code should be 0
-    And the /tmp/behat-wordpress-tests-lib directory should contain:
+    And the {RUN_DIR}/wordpress-tests-lib directory should contain:
       """
       data
       """
-    And the /tmp/behat-wordpress-tests-lib directory should contain:
+    And the {RUN_DIR}/wordpress-tests-lib directory should contain:
       """
       includes
       """
-    And the /tmp/behat-wordpress-tests-lib directory should contain:
+    And the {RUN_DIR}/wordpress-tests-lib directory should contain:
       """
       wp-tests-config.php
       """
-    And the /tmp/behat-wordpress directory should contain:
+    And the {RUN_DIR}/wordpress directory should contain:
       """
       index.php
       license.txt
@@ -104,10 +102,10 @@ Feature: Scaffold install-wp-tests.sh tests
       wp_cli_test_scaffold
       """
 
-    When I run `WP_TESTS_DIR=/tmp/behat-wordpress-tests-lib ./phpunit -c {PLUGIN_DIR}/hello-world/phpunit.xml.dist`
+    When I run `WP_TESTS_DIR={RUN_DIR}/wordpress-tests-lib ./phpunit -c {PLUGIN_DIR}/hello-world/phpunit.xml.dist`
     Then the return code should be 0
 
-    When I try `WP_TESTS_DIR=/tmp/behat-wordpress-tests-lib WP_CORE_DIR=/tmp/behat-wordpress /usr/bin/env bash {PLUGIN_DIR}/hello-world/bin/install-wp-tests.sh wp_cli_test_scaffold {DB_USER} {DB_PASSWORD} {DB_HOST} latest < affirmative-response`
+    When I try `WP_TESTS_DIR={RUN_DIR}/wordpress-tests-lib WP_CORE_DIR={RUN_DIR}/wordpress /usr/bin/env bash {PLUGIN_DIR}/hello-world/bin/install-wp-tests.sh wp_cli_test_scaffold {DB_USER} {DB_PASSWORD} {DB_HOST} latest < affirmative-response`
     Then the return code should be 0
     And STDERR should contain:
       """
@@ -118,7 +116,7 @@ Feature: Scaffold install-wp-tests.sh tests
       Recreated the database (wp_cli_test_scaffold)
       """
 
-    When I try `WP_TESTS_DIR=/tmp/behat-wordpress-tests-lib WP_CORE_DIR=/tmp/behat-wordpress /usr/bin/env bash {PLUGIN_DIR}/hello-world/bin/install-wp-tests.sh wp_cli_test_scaffold {DB_USER} {DB_PASSWORD} {DB_HOST} latest < negative-response`
+    When I try `WP_TESTS_DIR={RUN_DIR}/wordpress-tests-lib WP_CORE_DIR={RUN_DIR}/wordpress /usr/bin/env bash {PLUGIN_DIR}/hello-world/bin/install-wp-tests.sh wp_cli_test_scaffold {DB_USER} {DB_PASSWORD} {DB_HOST} latest < negative-response`
     Then the return code should be 0
     And STDERR should contain:
       """
@@ -167,24 +165,22 @@ Feature: Scaffold install-wp-tests.sh tests
     And I run `wp scaffold plugin hello-world`
     # This throws a warning for the password provided via command line.
     And I try `mysql -u{DB_USER} -p{DB_PASSWORD} -h{MYSQL_HOST} -P{MYSQL_PORT} --protocol=tcp -e "DROP DATABASE IF EXISTS wp_cli_test_scaffold"`
-    And I try `rm -fr /tmp/behat-wordpress-tests-lib`
-    And I try `rm -fr /tmp/behat-wordpress`
 
-    When I try `WP_TESTS_DIR=/tmp/behat-wordpress-tests-lib WP_CORE_DIR=/tmp/behat-wordpress /usr/bin/env bash {PLUGIN_DIR}/hello-world/bin/install-wp-tests.sh wp_cli_test_scaffold {DB_USER} {DB_PASSWORD} {DB_HOST} latest`
+    When I try `WP_TESTS_DIR={RUN_DIR}/wordpress-tests-lib WP_CORE_DIR={RUN_DIR}/wordpress /usr/bin/env bash {PLUGIN_DIR}/hello-world/bin/install-wp-tests.sh wp_cli_test_scaffold {DB_USER} {DB_PASSWORD} {DB_HOST} latest`
     Then the return code should be 0
-    And the /tmp/behat-wordpress-tests-lib directory should contain:
+    And the {RUN_DIR}/wordpress-tests-lib directory should contain:
       """
       data
       """
-    And the /tmp/behat-wordpress-tests-lib directory should contain:
+    And the {RUN_DIR}/wordpress-tests-lib directory should contain:
       """
       includes
       """
-    And the /tmp/behat-wordpress-tests-lib directory should contain:
+    And the {RUN_DIR}/wordpress-tests-lib directory should contain:
       """
       wp-tests-config.php
       """
-    And the /tmp/behat-wordpress directory should contain:
+    And the {RUN_DIR}/wordpress directory should contain:
       """
       index.php
       license.txt
@@ -219,14 +215,14 @@ Feature: Scaffold install-wp-tests.sh tests
       wp_cli_test_scaffold
       """
 
-    When I try `WP_TESTS_DIR=/tmp/behat-wordpress-tests-lib ./phpunit -c {PLUGIN_DIR}/hello-world/phpunit.xml.dist`
+    When I try `WP_TESTS_DIR={RUN_DIR}/wordpress-tests-lib ./phpunit -c {PLUGIN_DIR}/hello-world/phpunit.xml.dist`
     Then the return code should be 1
     And STDOUT should contain:
       """
       The scaffolded tests cannot currently be run on PHP 8.0+. See https://github.com/wp-cli/scaffold-command/issues/285
       """
 
-    When I try `WP_TESTS_DIR=/tmp/behat-wordpress-tests-lib WP_CORE_DIR=/tmp/behat-wordpress /usr/bin/env bash {PLUGIN_DIR}/hello-world/bin/install-wp-tests.sh wp_cli_test_scaffold {DB_USER} {DB_PASSWORD} {DB_HOST} latest < affirmative-response`
+    When I try `WP_TESTS_DIR={RUN_DIR}/wordpress-tests-lib WP_CORE_DIR={RUN_DIR}/wordpress /usr/bin/env bash {PLUGIN_DIR}/hello-world/bin/install-wp-tests.sh wp_cli_test_scaffold {DB_USER} {DB_PASSWORD} {DB_HOST} latest < affirmative-response`
     Then the return code should be 0
     And STDERR should contain:
       """
@@ -237,7 +233,7 @@ Feature: Scaffold install-wp-tests.sh tests
       Recreated the database (wp_cli_test_scaffold)
       """
 
-    When I try `WP_TESTS_DIR=/tmp/behat-wordpress-tests-lib WP_CORE_DIR=/tmp/behat-wordpress /usr/bin/env bash {PLUGIN_DIR}/hello-world/bin/install-wp-tests.sh wp_cli_test_scaffold {DB_USER} {DB_PASSWORD} {DB_HOST} latest < negative-response`
+    When I try `WP_TESTS_DIR={RUN_DIR}/wordpress-tests-lib WP_CORE_DIR={RUN_DIR}/wordpress /usr/bin/env bash {PLUGIN_DIR}/hello-world/bin/install-wp-tests.sh wp_cli_test_scaffold {DB_USER} {DB_PASSWORD} {DB_HOST} latest < negative-response`
     Then the return code should be 0
     And STDERR should contain:
       """
@@ -248,7 +244,6 @@ Feature: Scaffold install-wp-tests.sh tests
       Leaving the existing database (wp_cli_test_scaffold) in place
       """
 
-  @require-php-5.6 @less-than-php-8.0
   Scenario: Install WordPress from trunk
     Given a WP install
     And a get-phpunit-phar-url.php file:
@@ -278,31 +273,29 @@ Feature: Scaffold install-wp-tests.sh tests
     And I run `wp scaffold plugin hello-world`
     # This throws a warning for the password provided via command line.
     And I try `mysql -u{DB_USER} -p{DB_PASSWORD} -h{MYSQL_HOST} -P{MYSQL_PORT} --protocol=tcp -e "DROP DATABASE IF EXISTS wp_cli_test_scaffold"`
-    And I try `rm -fr /tmp/behat-wordpress-tests-lib`
-    And I try `rm -fr /tmp/behat-wordpress`
 
-    When I try `WP_TESTS_DIR=/tmp/behat-wordpress-tests-lib WP_CORE_DIR=/tmp/behat-wordpress /usr/bin/env bash {PLUGIN_DIR}/hello-world/bin/install-wp-tests.sh wp_cli_test_scaffold {DB_USER} {DB_PASSWORD} {DB_HOST} trunk`
+    When I try `WP_TESTS_DIR={RUN_DIR}/wordpress-tests-lib WP_CORE_DIR={RUN_DIR}/wordpress /usr/bin/env bash {PLUGIN_DIR}/hello-world/bin/install-wp-tests.sh wp_cli_test_scaffold {DB_USER} {DB_PASSWORD} {DB_HOST} trunk`
     Then the return code should be 0
-    And the /tmp/behat-wordpress-tests-lib directory should contain:
+    And the {RUN_DIR}/wordpress-tests-lib directory should contain:
       """
       data
       """
-    And the /tmp/behat-wordpress-tests-lib directory should contain:
+    And the {RUN_DIR}/wordpress-tests-lib directory should contain:
       """
       includes
       """
-    And the /tmp/behat-wordpress-tests-lib directory should contain:
+    And the {RUN_DIR}/wordpress-tests-lib directory should contain:
       """
       wp-tests-config.php
       """
-    And the /tmp/behat-wordpress directory should contain:
+    And the {RUN_DIR}/wordpress directory should contain:
       """
       index.php
       """
 
     # WP 5.0+: js
 
-    And the /tmp/behat-wordpress directory should contain:
+    And the {RUN_DIR}/wordpress directory should contain:
       """
       license.txt
       readme.html
@@ -310,7 +303,7 @@ Feature: Scaffold install-wp-tests.sh tests
 
     # WP 5.0+: styles
 
-    And the /tmp/behat-wordpress directory should contain:
+    And the {RUN_DIR}/wordpress directory should contain:
       """
       wp-activate.php
       wp-admin
@@ -329,7 +322,7 @@ Feature: Scaffold install-wp-tests.sh tests
       wp-trackback.php
       xmlrpc.php
       """
-    And the contents of the /tmp/behat-wordpress/wp-includes/version.php file should match /\-(alpha|beta[0-9]+|RC[0-9]+)\-/
+    And the contents of the {RUN_DIR}/wordpress/wp-includes/version.php file should match /\-(alpha|beta[0-9]+|RC[0-9]+)\-/
     And the {PLUGIN_DIR}/hello-world/phpunit.xml.dist file should exist
     And STDERR should contain:
       """
@@ -343,110 +336,14 @@ Feature: Scaffold install-wp-tests.sh tests
       wp_cli_test_scaffold
       """
 
-    When I run `WP_TESTS_DIR=/tmp/behat-wordpress-tests-lib ./phpunit -c {PLUGIN_DIR}/hello-world/phpunit.xml.dist`
+    When I run `composer init --no-interaction --quiet --name=wp-cli/test-scenario --require="yoast/phpunit-polyfills=^1.0.1" --working-dir={RUN_DIR}/wordpress-tests-lib`
     Then the return code should be 0
 
-  @require-php-8.0
-  Scenario: Install WordPress from trunk for PHP 8.0+
-    Given a WP install
-    And a get-phpunit-phar-url.php file:
-    """
-    <?php
-    $version = 4;
-    if(PHP_VERSION_ID >= 50600) {
-        $version = 5;
-    }
-    if(PHP_VERSION_ID >= 70000) {
-        $version = 6;
-    }
-    if(PHP_VERSION_ID >= 70100) {
-        $version = 7;
-    }
-    if(PHP_VERSION_ID >= 80000) {
-        $version = 9;
-    }
-    echo "https://phar.phpunit.de/phpunit-{$version}.phar";
-    """
-    And I run `wp eval-file get-phpunit-phar-url.php --skip-wordpress`
-    And save STDOUT as {PHPUNIT_PHAR_URL}
-    And I run `wget -q -O phpunit {PHPUNIT_PHAR_URL}`
-    And I run `chmod +x phpunit`
-    And I run `wp plugin path`
-    And save STDOUT as {PLUGIN_DIR}
-    And I run `wp scaffold plugin hello-world`
-    # This throws a warning for the password provided via command line.
-    And I try `mysql -u{DB_USER} -p{DB_PASSWORD} -h{MYSQL_HOST} -P{MYSQL_PORT} --protocol=tcp -e "DROP DATABASE IF EXISTS wp_cli_test_scaffold"`
-    And I try `rm -fr /tmp/behat-wordpress-tests-lib`
-    And I try `rm -fr /tmp/behat-wordpress`
-
-    When I try `WP_TESTS_DIR=/tmp/behat-wordpress-tests-lib WP_CORE_DIR=/tmp/behat-wordpress /usr/bin/env bash {PLUGIN_DIR}/hello-world/bin/install-wp-tests.sh wp_cli_test_scaffold {DB_USER} {DB_PASSWORD} {DB_HOST} trunk`
+    When I run `composer install --no-interaction --quiet --working-dir={RUN_DIR}/wordpress-tests-lib`
     Then the return code should be 0
-    And the /tmp/behat-wordpress-tests-lib directory should contain:
-      """
-      data
-      """
-    And the /tmp/behat-wordpress-tests-lib directory should contain:
-      """
-      includes
-      """
-    And the /tmp/behat-wordpress-tests-lib directory should contain:
-      """
-      wp-tests-config.php
-      """
-    And the /tmp/behat-wordpress directory should contain:
-      """
-      index.php
-      """
 
-    # WP 5.0+: js
-
-    And the /tmp/behat-wordpress directory should contain:
-      """
-      license.txt
-      readme.html
-      """
-
-    # WP 5.0+: styles
-
-    And the /tmp/behat-wordpress directory should contain:
-      """
-      wp-activate.php
-      wp-admin
-      wp-blog-header.php
-      wp-comments-post.php
-      wp-config-sample.php
-      wp-content
-      wp-cron.php
-      wp-includes
-      wp-links-opml.php
-      wp-load.php
-      wp-login.php
-      wp-mail.php
-      wp-settings.php
-      wp-signup.php
-      wp-trackback.php
-      xmlrpc.php
-      """
-    And the contents of the /tmp/behat-wordpress/wp-includes/version.php file should match /\-(alpha|beta[0-9]+|RC[0-9]+)\-/
-    And the {PLUGIN_DIR}/hello-world/phpunit.xml.dist file should exist
-    And STDERR should contain:
-      """
-      install_test_suite
-      """
-
-    # This throws a warning for the password provided via command line.
-    When I try `mysql -u{DB_USER} -p{DB_PASSWORD} -h{MYSQL_HOST} -P{MYSQL_PORT} --protocol=tcp -e "SHOW DATABASES"`
-    And STDOUT should contain:
-      """
-      wp_cli_test_scaffold
-      """
-
-    When I try `WP_TESTS_DIR=/tmp/behat-wordpress-tests-lib ./phpunit -c {PLUGIN_DIR}/hello-world/phpunit.xml.dist`
-    Then the return code should be 1
-    And STDOUT should contain:
-      """
-      The scaffolded tests cannot currently be run on PHP 8.0+. See https://github.com/wp-cli/scaffold-command/issues/285
-      """
+    When I run `WP_TESTS_DIR={RUN_DIR}/wordpress-tests-lib WP_TESTS_PHPUNIT_POLYFILLS_PATH={RUN_DIR}/wordpress-tests-lib/vendor/yoast/phpunit-polyfills ./phpunit -c {PLUGIN_DIR}/hello-world/phpunit.xml.dist`
+    Then the return code should be 0
 
   Scenario: Install WordPress 3.7 and phpunit will not run
     Given a WP install
@@ -455,24 +352,22 @@ Feature: Scaffold install-wp-tests.sh tests
     And I run `wp scaffold plugin hello-world`
     # This throws a warning for the password provided via command line.
     And I try `mysql -u{DB_USER} -p{DB_PASSWORD} -h{MYSQL_HOST} -P{MYSQL_PORT} --protocol=tcp -e "DROP DATABASE IF EXISTS wp_cli_test_scaffold"`
-    And I try `rm -fr /tmp/behat-wordpress-tests-lib`
-    And I try `rm -fr /tmp/behat-wordpress`
 
-    When I try `WP_TESTS_DIR=/tmp/behat-wordpress-tests-lib WP_CORE_DIR=/tmp/behat-wordpress /usr/bin/env bash {PLUGIN_DIR}/hello-world/bin/install-wp-tests.sh wp_cli_test_scaffold {DB_USER} {DB_PASSWORD} {DB_HOST} 3.7`
+    When I try `WP_TESTS_DIR={RUN_DIR}/wordpress-tests-lib WP_CORE_DIR={RUN_DIR}/wordpress /usr/bin/env bash {PLUGIN_DIR}/hello-world/bin/install-wp-tests.sh wp_cli_test_scaffold {DB_USER} {DB_PASSWORD} {DB_HOST} 3.7`
     Then the return code should be 0
-    And the /tmp/behat-wordpress-tests-lib directory should contain:
+    And the {RUN_DIR}/wordpress-tests-lib directory should contain:
       """
       data
       """
-    And the /tmp/behat-wordpress-tests-lib directory should contain:
+    And the {RUN_DIR}/wordpress-tests-lib directory should contain:
       """
       includes
       """
-    And the /tmp/behat-wordpress-tests-lib directory should contain:
+    And the {RUN_DIR}/wordpress-tests-lib directory should contain:
       """
       wp-tests-config.php
       """
-    And the /tmp/behat-wordpress directory should contain:
+    And the {RUN_DIR}/wordpress directory should contain:
       """
       index.php
       license.txt
@@ -494,7 +389,7 @@ Feature: Scaffold install-wp-tests.sh tests
       wp-trackback.php
       xmlrpc.php
       """
-    And the /tmp/behat-wordpress/wp-includes/version.php file should contain:
+    And the {RUN_DIR}/wordpress/wp-includes/version.php file should contain:
       """
       3.7
       """

--- a/features/scaffold-theme-tests.feature
+++ b/features/scaffold-theme-tests.feature
@@ -88,7 +88,6 @@ Feature: Scaffold theme unit tests
       """
       <?php echo __FILE__ . " loaded.\n";
       """
-    # TODO: Hardcoded for GHA, needs to be made more flexible for local setups.
     # This throws a warning for the password provided via command line.
     And I try `mysql -u{DB_USER} -p{DB_PASSWORD} -h{MYSQL_HOST} -P{MYSQL_PORT} --protocol=tcp -e "DROP DATABASE IF EXISTS wp_cli_test_scaffold"`
     And I try `rm -fr /tmp/behat-wordpress-tests-lib`

--- a/features/scaffold-theme-tests.feature
+++ b/features/scaffold-theme-tests.feature
@@ -91,7 +91,7 @@ Feature: Scaffold theme unit tests
     # This throws a warning for the password provided via command line.
     And I try `mysql -u{DB_USER} -p{DB_PASSWORD} -h{MYSQL_HOST} -P{MYSQL_PORT} --protocol=tcp -e "DROP DATABASE IF EXISTS wp_cli_test_scaffold"`
 
-	  And I try `WP_TESTS_DIR={RUN_DIR}/wordpress-tests-lib WP_CORE_DIR={RUN_DIR}/wordpress {THEME_DIR}/p2child/bin/install-wp-tests.sh wp_cli_test_scaffold {DB_USER} {DB_PASSWORD} {DB_HOST} latest`
+    And I try `WP_TESTS_DIR={RUN_DIR}/wordpress-tests-lib WP_CORE_DIR={RUN_DIR}/wordpress {THEME_DIR}/p2child/bin/install-wp-tests.sh wp_cli_test_scaffold {DB_USER} {DB_PASSWORD} {DB_HOST} latest`
     Then the return code should be 0
 
     When I run `cd {THEME_DIR}/p2child; WP_TESTS_DIR={RUN_DIR}/wordpress-tests-lib phpunit`

--- a/features/scaffold-theme-tests.feature
+++ b/features/scaffold-theme-tests.feature
@@ -90,12 +90,11 @@ Feature: Scaffold theme unit tests
       """
     # This throws a warning for the password provided via command line.
     And I try `mysql -u{DB_USER} -p{DB_PASSWORD} -h{MYSQL_HOST} -P{MYSQL_PORT} --protocol=tcp -e "DROP DATABASE IF EXISTS wp_cli_test_scaffold"`
-    And I try `rm -fr /tmp/behat-wordpress-tests-lib`
-    And I try `rm -fr /tmp/behat-wordpress`
-	  And I try `WP_TESTS_DIR=/tmp/behat-wordpress-tests-lib WP_CORE_DIR=/tmp/behat-wordpress {THEME_DIR}/p2child/bin/install-wp-tests.sh wp_cli_test_scaffold {DB_USER} {DB_PASSWORD} {DB_HOST} latest`
+
+	  And I try `WP_TESTS_DIR={RUN_DIR}/wordpress-tests-lib WP_CORE_DIR={RUN_DIR}/wordpress {THEME_DIR}/p2child/bin/install-wp-tests.sh wp_cli_test_scaffold {DB_USER} {DB_PASSWORD} {DB_HOST} latest`
     Then the return code should be 0
 
-    When I run `cd {THEME_DIR}/p2child; WP_TESTS_DIR=/tmp/behat-wordpress-tests-lib phpunit`
+    When I run `cd {THEME_DIR}/p2child; WP_TESTS_DIR={RUN_DIR}/wordpress-tests-lib phpunit`
     Then STDOUT should contain:
       """
       p2child/functions.php loaded.
@@ -109,7 +108,7 @@ Feature: Scaffold theme unit tests
       No tests executed!
       """
 
-    When I run `cd {THEME_DIR}/p2child; WP_MULTISITE=1 WP_TESTS_DIR=/tmp/behat-wordpress-tests-lib phpunit`
+    When I run `cd {THEME_DIR}/p2child; WP_MULTISITE=1 WP_TESTS_DIR={RUN_DIR}/wordpress-tests-lib phpunit`
     Then STDOUT should contain:
       """
       p2child/functions.php loaded.

--- a/templates/plugin-bootstrap.mustache
+++ b/templates/plugin-bootstrap.mustache
@@ -16,6 +16,12 @@ if ( ! $_tests_dir ) {
 	$_tests_dir = rtrim( sys_get_temp_dir(), '/\\' ) . '/wordpress-tests-lib';
 }
 
+// Forward custom PHPUnit Polyfills configuration to PHPUnit bootstrap file.
+$_phpunit_polyfills_path = getenv( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH' );
+if ( false !== $_phpunit_polyfills_path ) {
+	define( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH', $_phpunit_polyfills_path );
+}
+
 if ( ! file_exists( "{$_tests_dir}/includes/functions.php" ) ) {
 	echo "Could not find {$_tests_dir}/includes/functions.php, have you run bin/install-wp-tests.sh ?" . PHP_EOL; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	exit( 1 );

--- a/templates/plugin-bootstrap.mustache
+++ b/templates/plugin-bootstrap.mustache
@@ -5,11 +5,6 @@
  * @package {{plugin_package}}
  */
 
-if ( PHP_MAJOR_VERSION >= 8 ) {
-	echo "The scaffolded tests cannot currently be run on PHP 8.0+. See https://github.com/wp-cli/scaffold-command/issues/285" . PHP_EOL; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-	exit( 1 );
-}
-
 $_tests_dir = getenv( 'WP_TESTS_DIR' );
 
 if ( ! $_tests_dir ) {


### PR DESCRIPTION
This PR adds support for the new PHPUnit polyfills for WP core trunk.

It also removes the distinction between running tests on PHP < 8 and PHP >= 8, as it now works across the entire version spectrum.

Fixes #285 