### PR TITLE
Deprecate `wp scaffold block` in favor of `@wordpress/create-block`

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,11 +91,11 @@ Generates PHP, JS and CSS code for registering a Gutenberg block for a plugin or
 wp scaffold block <slug> [--title=<title>] [--dashicon=<dashicon>] [--category=<category>] [--theme] [--plugin=<plugin>] [--force]
 ~~~
 
-Blocks are the fundamental element of the Gutenberg editor. They are the primary way in which plugins and themes can register their own functionality and extend the capabilities of the editor.
+**Warning: `wp scaffold block` is deprecated.**
 
-Visit the [Gutenberg handbook](https://wordpress.org/gutenberg/handbook/block-api/) to learn more about Block API.
+The official script to generate a block is the [@wordpress/create-block](https://developer.wordpress.org/block-editor/designers-developers/developers/packages/packages-create-block/) package.
 
-When you scaffold a block you must use either the theme or plugin option. The latter is recommended.
+See the [Create a Block tutorial](https://developer.wordpress.org/block-editor/getting-started/create-block/) for a complete walk-through.
 
 **OPTIONS**
 
@@ -128,24 +128,6 @@ When you scaffold a block you must use either the theme or plugin option. The la
 
 	[--force]
 		Overwrite files that already exist.
-
-**EXAMPLES**
-
-    # Generate a 'movie' block for the 'movies' plugin
-    $ wp scaffold block movie --title="Movie block" --plugin=movies
-    Success: Created block 'Movie block'.
-
-    # Generate a 'movie' block for the 'simple-life' theme
-    $ wp scaffold block movie --title="Movie block" --theme=simple-life
-     Success: Created block 'Movie block'.
-
-    # Create a new plugin and add two blocks
-    # Create plugin called books
-    $ wp scaffold plugin books
-    # Add a block called book to plugin books
-    $ wp scaffold block book --title="Book" --plugin=books
-    # Add a second block to plugin called books.
-    $ wp scaffold block books --title="Book List" --plugin=books
 
 
 

--- a/src/Scaffold_Command.php
+++ b/src/Scaffold_Command.php
@@ -204,11 +204,11 @@ class Scaffold_Command extends WP_CLI_Command {
 	/**
 	 * Generates PHP, JS and CSS code for registering a Gutenberg block for a plugin or theme.
 	 *
-	 * Blocks are the fundamental element of the Gutenberg editor. They are the primary way in which plugins and themes can register their own functionality and extend the capabilities of the editor.
+	 * **Warning: `wp scaffold block` is deprecated.**
 	 *
-	 * Visit the [Gutenberg handbook](https://wordpress.org/gutenberg/handbook/block-api/) to learn more about Block API.
+	 * The official script to generate a block is the [@wordpress/create-block](https://developer.wordpress.org/block-editor/designers-developers/developers/packages/packages-create-block/) package.
 	 *
-	 * When you scaffold a block you must use either the theme or plugin option. The latter is recommended.
+	 * See the [Create a Block tutorial](https://developer.wordpress.org/block-editor/getting-started/create-block/) for a complete walk-through.
 	 *
 	 * ## OPTIONS
 	 *
@@ -241,24 +241,6 @@ class Scaffold_Command extends WP_CLI_Command {
 	 *
 	 * [--force]
 	 * : Overwrite files that already exist.
-	 *
-	 * ## EXAMPLES
-	 *
-	 *     # Generate a 'movie' block for the 'movies' plugin
-	 *     $ wp scaffold block movie --title="Movie block" --plugin=movies
-	 *     Success: Created block 'Movie block'.
-	 *
-	 *     # Generate a 'movie' block for the 'simple-life' theme
-	 *     $ wp scaffold block movie --title="Movie block" --theme=simple-life
-	 *      Success: Created block 'Movie block'.
-	 *
-	 *     # Create a new plugin and add two blocks
-	 *     # Create plugin called books
-	 *     $ wp scaffold plugin books
-	 *     # Add a block called book to plugin books
-	 *     $ wp scaffold block book --title="Book" --plugin=books
-	 *     # Add a second block to plugin called books.
-	 *     $ wp scaffold block books --title="Book List" --plugin=books
 	 *
 	 * @subcommand block
 	 */


### PR DESCRIPTION
From #308