### PR TITLE
Add phpcompatibility-wp coding standards to Gitlab template

### DIFF
--- a/templates/plugin-gitlab.mustache
+++ b/templates/plugin-gitlab.mustache
@@ -5,7 +5,7 @@ variables:
 
 before_script:
   # Install dependencies
-  
+
   # update the docker
   - apt-get clean
   - apt-get -yqq update
@@ -22,7 +22,9 @@ before_script:
   # Install PHPCS and WPCS
   - composer global require "squizlabs/php_codesniffer=*"
   - composer global require "wp-coding-standards/wpcs"
-  - phpcs --config-set installed_paths $HOME/.composer/vendor/wp-coding-standards/wpcs
+  - composer global require "phpcompatibility/phpcompatibility-wp"
+  - vendor="$HOME/.composer/vendor"
+  - phpcs --config-set installed_paths "$vendor/wp-coding-standards/wpcs,$vendor/phpcompatibility/php-compatibility,$vendor/phpcompatibility/phpcompatibility-paragonie,$vendor/phpcompatibility/phpcompatibility-wp"
 
 PHPunit:PHP5.3:MySQL:
   image: tetraweb/php:5.3
@@ -39,7 +41,7 @@ PHPunit:PHP5.6:MySQL:
   script:
   - phpcs
   - phpunit
-  
+
 PHPunit:PHP7.0:MySQL:
   image: tetraweb/php:7.0
   services:


### PR DESCRIPTION
Add phpcompatibility-wp coding standards to Gitlab template.

Phpcompatibility-wp is required here:
https://github.com/wp-cli/scaffold-command/blob/4a142380157b43de3179bf3a3132b97d81442e48/templates/.phpcs.xml.dist#L23

Phpcompatibility-wp is already used in Travis template:
https://github.com/wp-cli/scaffold-command/blob/4a142380157b43de3179bf3a3132b97d81442e48/templates/plugin-travis.mustache#L53-L57

Phpcompatibility-wp will always include php-compatibility and phpcompatibility-paragonie too:
https://github.com/PHPCompatibility/PHPCompatibilityWP/blob/ed2685318d3af3cd9a1676bea8e3ffc3a972b3b1/composer.json#L26