### PR TITLE
Update the github URL for db.php

### DIFF
--- a/templates/install-wp-tests.sh
+++ b/templates/install-wp-tests.sh
@@ -92,7 +92,7 @@ install_wp() {
 		tar --strip-components=1 -zxmf $TMPDIR/wordpress.tar.gz -C $WP_CORE_DIR
 	fi
 
-	download https://raw.github.com/markoheijnen/wp-mysqli/master/db.php $WP_CORE_DIR/wp-content/db.php
+	download https://raw.githubusercontent.com/markoheijnen/wp-mysqli/master/db.php $WP_CORE_DIR/wp-content/db.php
 }
 
 install_test_suite() {


### PR DESCRIPTION
Update the URL used for db.php to reflect the proper URL from Github: https://raw.githubusercontent.com/markoheijnen/wp-mysqli/master/db.php

At the time of writing, https://raw.github.com/markoheijnen/wp-mysqli/master/db.php is throwing a 503 error (`Error 503 hostname doesn't match against certificate`). The correct raw URL doesn't 503.