### PR TITLE
Run test only on PHP 7.0+

### DIFF
--- a/features/install-wp-tests.feature
+++ b/features/install-wp-tests.feature
@@ -14,7 +14,7 @@ Feature: Scaffold install-wp-tests.sh tests
       """
     And the return code should be 1
 
-  @less-than-php-8.0
+  @less-than-php-8.0 @require-php-7.0
   Scenario: Install latest version of WordPress
     Given a WP install
     And a affirmative-response file:

--- a/features/scaffold-theme-tests.feature
+++ b/features/scaffold-theme-tests.feature
@@ -8,7 +8,7 @@ Feature: Scaffold theme unit tests
     When I run `wp theme path`
     Then save STDOUT as {THEME_DIR}
 
-  @require-php-5.6 @less-than-php-7.2
+  @require-php-7.0 @less-than-php-7.2
   Scenario: Scaffold theme tests
     When I run `wp scaffold theme-tests p2child`
     Then STDOUT should not be empty


### PR DESCRIPTION
Tests involving the WP release can now only run on PHP 7.0+ due to the new minimum requirement.

<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->
