### PR TITLE
Add `@require-mysql` for tests with explicit MySQL dependency

### DIFF
--- a/features/install-wp-tests.feature
+++ b/features/install-wp-tests.feature
@@ -264,7 +264,7 @@ Feature: Scaffold install-wp-tests.sh tests
       Leaving the existing database (wp_cli_test_scaffold) in place
       """
 
-  @require-php-8.0 @require-wp-5.8
+  @require-php-8.0 @require-wp-5.8 @require-mysql
   Scenario: Install latest version of WordPress on PHP 8.0+ and WordPress above 5.8
     Given a WP install
     And a affirmative-response file:
@@ -383,7 +383,7 @@ Feature: Scaffold install-wp-tests.sh tests
       Leaving the existing database (wp_cli_test_scaffold) in place
       """
 
-  @require-php-7.0
+  @require-php-7.0 @require-mysql
   Scenario: Install WordPress from trunk
     Given a WP install
     And a get-phpunit-phar-url.php file:
@@ -485,6 +485,7 @@ Feature: Scaffold install-wp-tests.sh tests
     When I run `WP_TESTS_DIR={RUN_DIR}/wordpress-tests-lib WP_TESTS_PHPUNIT_POLYFILLS_PATH={RUN_DIR}/wordpress-tests-lib/vendor/yoast/phpunit-polyfills ./phpunit -c {PLUGIN_DIR}/hello-world/phpunit.xml.dist`
     Then the return code should be 0
 
+  @require-mysql
   Scenario: Install WordPress 3.7 and phpunit will not run
     Given a WP install
     And I run `wp plugin path`

--- a/features/install-wp-tests.feature
+++ b/features/install-wp-tests.feature
@@ -14,7 +14,7 @@ Feature: Scaffold install-wp-tests.sh tests
       """
     And the return code should be 1
 
-  @less-than-php-8.0 @require-php-7.0
+  @less-than-php-8.0 @require-php-7.0 @require-mysql
   Scenario: Install latest version of WordPress
     Given a WP install
     And a affirmative-response file:

--- a/features/scaffold-theme-tests.feature
+++ b/features/scaffold-theme-tests.feature
@@ -8,7 +8,7 @@ Feature: Scaffold theme unit tests
     When I run `wp theme path`
     Then save STDOUT as {THEME_DIR}
 
-  @require-php-7.0 @less-than-php-7.2
+  @require-php-7.0 @less-than-php-7.2 @require-mysql
   Scenario: Scaffold theme tests
     When I run `wp scaffold theme-tests p2child`
     Then STDOUT should not be empty

--- a/features/scaffold.feature
+++ b/features/scaffold.feature
@@ -379,7 +379,7 @@ Feature: WordPress code scaffolding
     And the {THEME_DIR}/starter-theme/woocommerce.css file should exist
     And the {THEME_DIR}/starter-theme/inc/woocommerce.php file should exist
 
-  @require-php-5.6 @require-wp-4.6
+  @require-php-5.6 @require-wp-4.6 @require-mysql
   Scenario: Scaffold starter code for a theme and activate it
     Given a WP install
     # Allow for warnings to be generated due to https://github.com/wp-cli/scaffold-command/issues/181

--- a/features/scaffold.feature
+++ b/features/scaffold.feature
@@ -498,7 +498,7 @@ Feature: WordPress code scaffolding
       Success: Network enabled the 'Starter-theme' theme.
       """
 
-  @require-php-5.6 @require-wp-4.6
+  @require-php-5.6 @require-wp-4.6 @require-mysql
   Scenario: Scaffold starter code for a theme, but can't unzip theme files
     Given a WP install
     And a misconfigured WP_CONTENT_DIR constant directory


### PR DESCRIPTION
See https://github.com/wp-cli/.github/issues/94