### PR TITLE
Add GitHub as valid CI for plugin and theme scaffold

### DIFF
--- a/src/Scaffold_Command.php
+++ b/src/Scaffold_Command.php
@@ -607,7 +607,9 @@ class Scaffold_Command extends WP_CLI_Command {
 	 * default: circle
 	 * options:
 	 *   - circle
+	 *   - bitbucket
 	 *   - gitlab
+	 *   - github
 	 * ---
 	 *
 	 * [--activate]
@@ -733,6 +735,7 @@ class Scaffold_Command extends WP_CLI_Command {
 	 *   - circle
 	 *   - gitlab
 	 *   - bitbucket
+	 *   - github
 	 * ---
 	 *
 	 * [--force]
@@ -785,6 +788,7 @@ class Scaffold_Command extends WP_CLI_Command {
 	 *   - circle
 	 *   - gitlab
 	 *   - bitbucket
+	 *   - github
 	 * ---
 	 *
 	 * [--force]
@@ -882,6 +886,8 @@ class Scaffold_Command extends WP_CLI_Command {
 			$files_to_create[ "{$target_dir}/.gitlab-ci.yml" ] = self::mustache_render( 'plugin-gitlab.mustache' );
 		} elseif ( 'bitbucket' === $assoc_args['ci'] ) {
 			$files_to_create[ "{$target_dir}/bitbucket-pipelines.yml" ] = self::mustache_render( 'plugin-bitbucket.mustache' );
+		} elseif ( 'github' === $assoc_args['ci'] ) {
+			$files_to_create[ "{$target_dir}/.github/workflows/testing.yml" ] = self::mustache_render( 'plugin-github.mustache' );
 		}
 
 		$files_written = $this->create_files( $files_to_create, $force );

--- a/src/Scaffold_Command.php
+++ b/src/Scaffold_Command.php
@@ -607,7 +607,6 @@ class Scaffold_Command extends WP_CLI_Command {
 	 * default: circle
 	 * options:
 	 *   - circle
-	 *   - bitbucket
 	 *   - gitlab
 	 *   - github
 	 * ---
@@ -954,6 +953,12 @@ class Scaffold_Command extends WP_CLI_Command {
 			}
 
 			$wp_filesystem->mkdir( dirname( $filename ) );
+
+			// Create multi-level folders.
+			if ( false === $wp_filesystem->exists( dirname( $filename ) ) ) {
+				$wp_filesystem->mkdir( dirname( dirname( $filename ) ) );
+				$wp_filesystem->mkdir( dirname( $filename ) );
+			}
 
 			if ( ! $wp_filesystem->put_contents( $filename, $contents ) ) {
 				WP_CLI::error( "Error creating file: {$filename}" );

--- a/templates/plugin-github.mustache
+++ b/templates/plugin-github.mustache
@@ -1,0 +1,38 @@
+name: Testing
+
+on:
+  pull_request:
+    branches:
+      - main
+      - master
+
+jobs:
+  phpunit:
+    name: Run tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-version: ['8.2', '8.0', '7.4']
+    services:
+      database:
+        image: mysql:latest
+        env:
+          MYSQL_DATABASE: wordpress_tests
+          MYSQL_ROOT_PASSWORD: root
+        ports:
+          - 3306:3306
+    steps:
+      - name: Check out source code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          tools: phpunit-polyfills:1.1
+
+      - name: Setup tests
+        run: bash bin/install-wp-tests.sh wordpress_tests root root 127.0.0.1 latest true
+
+      - name: Run tests
+        run: phpunit


### PR DESCRIPTION
Fixes https://github.com/wp-cli/scaffold-command/issues/330

* Add `github` as valid option for `--ci` argument
* Add GitHub Actions file template
* When scaffolding, test file is copied to `.github/workflows/testing.yml`

Note:
For theme, in `theme-bootstrap.muscatche`, there is code for checking PHP version. So test is exited for PHP greater than 8.0. Is this still valid?
```
if ( PHP_MAJOR_VERSION >= 8 ) {
	echo "The scaffolded tests cannot currently be run on PHP 8.0+. See https://github.com/wp-cli/scaffold-command/issues/285" . PHP_EOL; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
	exit( 1 );
}

```
