### PR TITLE
Update trunk test to require PHP 7.2

### DIFF
--- a/features/install-wp-tests.feature
+++ b/features/install-wp-tests.feature
@@ -383,7 +383,7 @@ Feature: Scaffold install-wp-tests.sh tests
       Leaving the existing database (wp_cli_test_scaffold) in place
       """
 
-  @require-php-7.0 @require-mysql
+  @require-php-7.2 @require-mysql
   Scenario: Install WordPress from trunk
     Given a WP install
     And a get-phpunit-phar-url.php file:


### PR DESCRIPTION
Noticed here: https://github.com/wp-cli/automated-tests/actions/runs/8654969149/job/23733150212#step:14:230

Needed because of https://core.trac.wordpress.org/changeset/57985