### PR TITLE
Scaffold theme test should work in PHP greater than 8.0

### DIFF
--- a/templates/theme-bootstrap.mustache
+++ b/templates/theme-bootstrap.mustache
@@ -5,11 +5,6 @@
  * @package {{theme_package}}
  */
 
-if ( PHP_MAJOR_VERSION >= 8 ) {
-	echo "The scaffolded tests cannot currently be run on PHP 8.0+. See https://github.com/wp-cli/scaffold-command/issues/285" . PHP_EOL; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-	exit( 1 );
-}
-
 $_tests_dir = getenv( 'WP_TESTS_DIR' );
 
 if ( ! $_tests_dir ) {


### PR DESCRIPTION
This PR removes following code from `theme-bootstrap.mustache`:

```php
if ( PHP_MAJOR_VERSION >= 8 ) {
	echo "The scaffolded tests cannot currently be run on PHP 8.0+. See https://github.com/wp-cli/scaffold-command/issues/285" . PHP_EOL; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
	exit( 1 );
}
```

While working on https://github.com/wp-cli/scaffold-command/pull/331 I noticed this conditional is now not needed.

CC @schlessera - Ref https://github.com/wp-cli/scaffold-command/issues/285