### PR TITLE
Correct plugin main file in bootstrap in scaffolded test

### DIFF
--- a/features/scaffold-plugin-tests.feature
+++ b/features/scaffold-plugin-tests.feature
@@ -284,3 +284,28 @@ Feature: Scaffold plugin unit tests
       """
       bootstrap.php
       """
+
+  Scenario: Scaffold plugin tests with custom main file
+    Given a WP install
+    And a wp-content/plugins/foo/bar.php file:
+      """
+      <?php
+      /**
+       * Plugin Name:     Foo
+       * Plugin URI:      https://example.com
+       * Description:     Foo desctiption
+       * Author:          John Doe
+       * Author URI:      https://example.com
+       * Text Domain:     foo
+       * Domain Path:     /languages
+       * Version:         0.1.0
+       *
+       * @package  Foo
+       */
+      """
+
+    When I run `wp scaffold plugin-tests foo`
+    Then the wp-content/plugins/foo/tests/bootstrap.php file should contain:
+      """
+      require dirname( dirname( __FILE__ ) ) . '/bar.php';
+      """

--- a/src/Scaffold_Command.php
+++ b/src/Scaffold_Command.php
@@ -869,9 +869,29 @@ class Scaffold_Command extends WP_CLI_Command {
 		$wp_versions_to_test[] = 'latest';
 		$wp_versions_to_test[] = 'trunk';
 
+		$main_file = '';
+
+		if ( 'plugin' === $type ) {
+			$all_plugins = get_plugins();
+
+			if ( ! empty( $all_plugins ) ) {
+				$filtered = array_filter(
+					array_keys( $all_plugins ),
+					static function ( $item ) use ( $slug ) {
+						return ( false !== strpos( $item, "{$slug}/" ) );
+					}
+				);
+
+				if ( ! empty( $filtered ) ) {
+					$main_file = basename( reset( $filtered ) );
+				}
+			}
+		}
+
 		$template_data = [
-			"{$type}_slug"    => $slug,
-			"{$type}_package" => $package,
+			"{$type}_slug"      => $slug,
+			"{$type}_package"   => $package,
+			"{$type}_main_file" => $main_file,
 		];
 
 		$force           = Utils\get_flag_value( $assoc_args, 'force' );

--- a/src/Scaffold_Command.php
+++ b/src/Scaffold_Command.php
@@ -869,9 +869,13 @@ class Scaffold_Command extends WP_CLI_Command {
 		$wp_versions_to_test[] = 'latest';
 		$wp_versions_to_test[] = 'trunk';
 
-		$main_file = '';
+		$main_file = "{$slug}.php";
 
 		if ( 'plugin' === $type ) {
+			if ( ! function_exists( 'get_plugins' ) ) {
+				require_once ABSPATH . 'wp-admin/includes/plugin.php';
+			}
+
 			$all_plugins = get_plugins();
 
 			if ( ! empty( $all_plugins ) ) {

--- a/templates/plugin-bootstrap.mustache
+++ b/templates/plugin-bootstrap.mustache
@@ -29,7 +29,7 @@ require_once "{$_tests_dir}/includes/functions.php";
  * Manually load the plugin being tested.
  */
 function _manually_load_plugin() {
-	require dirname( dirname( __FILE__ ) ) . '/{{plugin_slug}}.php';
+	require dirname( dirname( __FILE__ ) ) . '/{{plugin_main_file}}';
 }
 
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );


### PR DESCRIPTION
Fixes https://github.com/wp-cli/scaffold-command/issues/190

* Use correct plugin main file in `tests/bootstrap.php` for in scaffolded tests
* Fallback name will be same as of now `plugin-slug.php`
* Feature test is also added