### PR TITLE
Update theme tests to remove P2 and use TwentyTwelve

### DIFF
--- a/features/scaffold-block.feature
+++ b/features/scaffold-block.feature
@@ -5,7 +5,7 @@ Feature: WordPress block code scaffolding
     Given I run `wp scaffold plugin movies`
     And I run `wp plugin path movies --dir`
     And save STDOUT as {PLUGIN_DIR}
-    Given I try `wp theme install twentytwelve --activate --force`
+    Given I run `wp theme install twentytwelve --activate --force`
     And I run `wp theme path twentytwelve --dir`
     And save STDOUT as {THEME_DIR}
 

--- a/features/scaffold-block.feature
+++ b/features/scaffold-block.feature
@@ -5,8 +5,8 @@ Feature: WordPress block code scaffolding
     Given I run `wp scaffold plugin movies`
     And I run `wp plugin path movies --dir`
     And save STDOUT as {PLUGIN_DIR}
-    Given I run `wp theme install p2 --activate`
-    And I run `wp theme path p2 --dir`
+    Given I try `wp theme install twentytwelve --activate --force`
+    And I run `wp theme path twentytwelve --dir`
     And save STDOUT as {THEME_DIR}
 
 
@@ -154,7 +154,7 @@ Feature: WordPress block code scaffolding
       """
 
   Scenario: Scaffold a block for a specific theme
-    When I run `wp scaffold block intouchables --theme=p2`
+    When I run `wp scaffold block intouchables --theme=twentytwelve`
     Then the {THEME_DIR}/blocks/intouchables.php file should exist
     And the {THEME_DIR}/blocks/intouchables/index.js file should exist
     And the {THEME_DIR}/blocks/intouchables/editor.css file should exist
@@ -166,7 +166,7 @@ Feature: WordPress block code scaffolding
 
   Scenario: Plugin- or theme-specific functions are only used in the correct context
     When I run `wp scaffold block plugin-block --plugin=movies`
-    And I run `wp scaffold block theme-block --theme=p2`
+    And I run `wp scaffold block theme-block --theme=twentytwelve`
     Then the {PLUGIN_DIR}/blocks/plugin-block.php file should contain:
       """
       plugins_url

--- a/features/scaffold-theme-tests.feature
+++ b/features/scaffold-theme-tests.feature
@@ -2,45 +2,45 @@ Feature: Scaffold theme unit tests
 
   Background:
     Given a WP install
-    And I run `wp theme install p2`
-    And I run `wp scaffold child-theme p2child --parent_theme=p2`
+    And I try `wp theme install twentytwelve --force`
+    And I run `wp scaffold child-theme t12child --parent_theme=twentytwelve`
 
     When I run `wp theme path`
     Then save STDOUT as {THEME_DIR}
 
   @require-php-7.0 @less-than-php-7.2 @require-mysql
   Scenario: Scaffold theme tests
-    When I run `wp scaffold theme-tests p2child`
+    When I run `wp scaffold theme-tests t12child`
     Then STDOUT should not be empty
-    And the {THEME_DIR}/p2child/tests directory should contain:
+    And the {THEME_DIR}/t12child/tests directory should contain:
       """
       bootstrap.php
       test-sample.php
       """
-    And the {THEME_DIR}/p2child/tests/bootstrap.php file should contain:
+    And the {THEME_DIR}/t12child/tests/bootstrap.php file should contain:
       """
       register_theme_directory( $theme_root );
       """
-    And the {THEME_DIR}/p2child/tests/bootstrap.php file should contain:
+    And the {THEME_DIR}/t12child/tests/bootstrap.php file should contain:
       """
-      * @package P2child
+      * @package T12child
       """
-    And the {THEME_DIR}/p2child/tests/test-sample.php file should contain:
+    And the {THEME_DIR}/t12child/tests/test-sample.php file should contain:
       """
-      * @package P2child
+      * @package T12child
       """
-    And the {THEME_DIR}/p2child/bin directory should contain:
+    And the {THEME_DIR}/t12child/bin directory should contain:
       """
       install-wp-tests.sh
       """
-    And the {THEME_DIR}/p2child/phpunit.xml.dist file should contain:
+    And the {THEME_DIR}/t12child/phpunit.xml.dist file should contain:
       """
       <exclude>./tests/test-sample.php</exclude>
       """
-    And the {THEME_DIR}/p2child/.phpcs.xml.dist file should exist
-    And the {THEME_DIR}/p2child/bitbucket-pipelines.yml file should not exist
-    And the {THEME_DIR}/p2child/.gitlab-ci.yml file should not exist
-    And the {THEME_DIR}/p2child/.circleci/config.yml file should contain:
+    And the {THEME_DIR}/t12child/.phpcs.xml.dist file should exist
+    And the {THEME_DIR}/t12child/bitbucket-pipelines.yml file should not exist
+    And the {THEME_DIR}/t12child/.gitlab-ci.yml file should not exist
+    And the {THEME_DIR}/t12child/.circleci/config.yml file should contain:
       """
       jobs:
         php56-build:
@@ -49,7 +49,7 @@ Feature: Scaffold theme unit tests
             - image: circleci/php:5.6
             - image: *mysql_image
       """
-    And the {THEME_DIR}/p2child/.circleci/config.yml file should contain:
+    And the {THEME_DIR}/t12child/.circleci/config.yml file should contain:
       """
       workflows:
         version: 2
@@ -63,27 +63,27 @@ Feature: Scaffold theme unit tests
             - php74-build
       """
 
-    When I run `wp eval "if ( is_executable( '{THEME_DIR}/p2child/bin/install-wp-tests.sh' ) ) { echo 'executable'; } else { exit( 1 ); }"`
+    When I run `wp eval "if ( is_executable( '{THEME_DIR}/t12child/bin/install-wp-tests.sh' ) ) { echo 'executable'; } else { exit( 1 ); }"`
     Then STDOUT should be:
       """
       executable
       """
 
     # Warning: overwriting generated functions.php file, so functions.php file loaded only tests beyond here...
-    Given a wp-content/themes/p2child/functions.php file:
+    Given a wp-content/themes/t12child/functions.php file:
       """
       <?php echo __FILE__ . " loaded.\n";
       """
     # This throws a warning for the password provided via command line.
     And I try `mysql -u{DB_USER} -p{DB_PASSWORD} -h{MYSQL_HOST} -P{MYSQL_PORT} --protocol=tcp -e "DROP DATABASE IF EXISTS wp_cli_test_scaffold"`
 
-    And I try `WP_TESTS_DIR={RUN_DIR}/wordpress-tests-lib WP_CORE_DIR={RUN_DIR}/wordpress {THEME_DIR}/p2child/bin/install-wp-tests.sh wp_cli_test_scaffold {DB_USER} {DB_PASSWORD} {DB_HOST} latest`
+    And I try `WP_TESTS_DIR={RUN_DIR}/wordpress-tests-lib WP_CORE_DIR={RUN_DIR}/wordpress {THEME_DIR}/t12child/bin/install-wp-tests.sh wp_cli_test_scaffold {DB_USER} {DB_PASSWORD} {DB_HOST} latest`
     Then the return code should be 0
 
-    When I run `cd {THEME_DIR}/p2child; WP_TESTS_DIR={RUN_DIR}/wordpress-tests-lib phpunit`
+    When I run `cd {THEME_DIR}/t12child; WP_TESTS_DIR={RUN_DIR}/wordpress-tests-lib phpunit`
     Then STDOUT should contain:
       """
-      p2child/functions.php loaded.
+      t12child/functions.php loaded.
       """
     And STDOUT should contain:
       """
@@ -94,10 +94,10 @@ Feature: Scaffold theme unit tests
       No tests executed!
       """
 
-    When I run `cd {THEME_DIR}/p2child; WP_MULTISITE=1 WP_TESTS_DIR={RUN_DIR}/wordpress-tests-lib phpunit`
+    When I run `cd {THEME_DIR}/t12child; WP_MULTISITE=1 WP_TESTS_DIR={RUN_DIR}/wordpress-tests-lib phpunit`
     Then STDOUT should contain:
       """
-      p2child/functions.php loaded.
+      t12child/functions.php loaded.
       """
     And STDOUT should contain:
       """
@@ -117,55 +117,55 @@ Feature: Scaffold theme unit tests
     And the return code should be 1
 
   Scenario: Scaffold theme tests with Circle as the provider
-    When I run `wp scaffold theme-tests p2child --ci=circle`
+    When I run `wp scaffold theme-tests t12child --ci=circle`
     Then STDOUT should not be empty
-    And the {THEME_DIR}/p2child/circle.yml file should not exist
-    And the {THEME_DIR}/p2child/.circleci/config.yml file should contain:
+    And the {THEME_DIR}/t12child/circle.yml file should not exist
+    And the {THEME_DIR}/t12child/.circleci/config.yml file should contain:
       """
       version: 2
       """
-    And the {THEME_DIR}/p2child/.circleci/config.yml file should contain:
+    And the {THEME_DIR}/t12child/.circleci/config.yml file should contain:
       """
       php56-build
       """
-    And the {THEME_DIR}/p2child/.circleci/config.yml file should contain:
+    And the {THEME_DIR}/t12child/.circleci/config.yml file should contain:
       """
       php70-build
       """
-    And the {THEME_DIR}/p2child/.circleci/config.yml file should contain:
+    And the {THEME_DIR}/t12child/.circleci/config.yml file should contain:
       """
       php71-build
       """
-    And the {THEME_DIR}/p2child/.circleci/config.yml file should contain:
+    And the {THEME_DIR}/t12child/.circleci/config.yml file should contain:
       """
       php72-build
       """
-    And the {THEME_DIR}/p2child/.circleci/config.yml file should contain:
+    And the {THEME_DIR}/t12child/.circleci/config.yml file should contain:
       """
       php73-build
       """
-    And the {THEME_DIR}/p2child/.circleci/config.yml file should contain:
+    And the {THEME_DIR}/t12child/.circleci/config.yml file should contain:
       """
       php74-build
       """
 
   Scenario: Scaffold theme tests with Gitlab as the provider
-    When I run `wp scaffold theme-tests p2child --ci=gitlab`
+    When I run `wp scaffold theme-tests t12child --ci=gitlab`
     Then STDOUT should not be empty
-    And the {THEME_DIR}/p2child/.gitlab-ci.yml file should contain:
+    And the {THEME_DIR}/t12child/.gitlab-ci.yml file should contain:
       """
       MYSQL_DATABASE
       """
 
   Scenario: Scaffold theme tests with Bitbucket Pipelines as the provider
-    When I run `wp scaffold theme-tests p2child --ci=bitbucket`
+    When I run `wp scaffold theme-tests t12child --ci=bitbucket`
     Then STDOUT should not be empty
-    And the {THEME_DIR}/p2child/bitbucket-pipelines.yml file should contain:
+    And the {THEME_DIR}/t12child/bitbucket-pipelines.yml file should contain:
       """
       pipelines:
         default:
       """
-    And the {THEME_DIR}/p2child/bitbucket-pipelines.yml file should contain:
+    And the {THEME_DIR}/t12child/bitbucket-pipelines.yml file should contain:
       """
           - step:
               image: php:5.6
@@ -175,7 +175,7 @@ Feature: Scaffold theme unit tests
                 - docker-php-ext-install mysqli
                 - apt-get update && apt-get install -y subversion --no-install-recommends
       """
-    And the {THEME_DIR}/p2child/bitbucket-pipelines.yml file should contain:
+    And the {THEME_DIR}/t12child/bitbucket-pipelines.yml file should contain:
       """
           - step:
               image: php:7.0
@@ -185,7 +185,7 @@ Feature: Scaffold theme unit tests
                 - docker-php-ext-install mysqli
                 - apt-get update && apt-get install -y subversion --no-install-recommends
       """
-    And the {THEME_DIR}/p2child/bitbucket-pipelines.yml file should contain:
+    And the {THEME_DIR}/t12child/bitbucket-pipelines.yml file should contain:
       """
           - step:
               image: php:7.1
@@ -195,7 +195,7 @@ Feature: Scaffold theme unit tests
                 - docker-php-ext-install mysqli
                 - apt-get update && apt-get install -y subversion --no-install-recommends
       """
-    And the {THEME_DIR}/p2child/bitbucket-pipelines.yml file should contain:
+    And the {THEME_DIR}/t12child/bitbucket-pipelines.yml file should contain:
       """
           - step:
               image: php:7.2
@@ -205,7 +205,7 @@ Feature: Scaffold theme unit tests
                 - docker-php-ext-install mysqli
                 - apt-get update && apt-get install -y subversion --no-install-recommends
       """
-    And the {THEME_DIR}/p2child/bitbucket-pipelines.yml file should contain:
+    And the {THEME_DIR}/t12child/bitbucket-pipelines.yml file should contain:
       """
       definitions:
         services:
@@ -233,7 +233,7 @@ Feature: Scaffold theme unit tests
     And the return code should be 1
 
   Scenario: Scaffold theme tests with invalid directory
-    When I try `wp scaffold theme-tests p2 --dir=non-existent-dir`
+    When I try `wp scaffold theme-tests twentytwelve --dir=non-existent-dir`
     Then STDERR should be:
       """
       Error: Invalid theme directory specified. No such directory 'non-existent-dir'.
@@ -241,18 +241,18 @@ Feature: Scaffold theme unit tests
     And the return code should be 1
 
     # Temporarily move.
-    When I run `mv -f {THEME_DIR}/p2 {THEME_DIR}/hide-p2 && touch {THEME_DIR}/p2`
+    When I run `mv -f {THEME_DIR}/twentytwelve {THEME_DIR}/hide-twentytwelve && touch {THEME_DIR}/twentytwelve`
     Then the return code should be 0
 
-    When I try `wp scaffold theme-tests p2`
+    When I try `wp scaffold theme-tests twentytwelve`
     Then STDERR should be:
       """
-      Error: Invalid theme slug specified. No such target directory '{THEME_DIR}/p2'.
+      Error: Invalid theme slug specified. No such target directory '{THEME_DIR}/twentytwelve'.
       """
     And the return code should be 1
 
     # Restore.
-    When I run `rm -f {THEME_DIR}/p2 && mv -f {THEME_DIR}/hide-p2 {THEME_DIR}/p2`
+    When I run `rm -f {THEME_DIR}/twentytwelve && mv -f {THEME_DIR}/hide-twentytwelve {THEME_DIR}/twentytwelve`
     Then the return code should be 0
 
   Scenario: Scaffold theme tests with a symbolic link
@@ -260,9 +260,9 @@ Feature: Scaffold theme unit tests
     When I run `mv -f {THEME_DIR} {RUN_DIR}/alt-themes && ln -s {RUN_DIR}/alt-themes {THEME_DIR}`
     Then the return code should be 0
 
-    When I run `wp scaffold theme-tests p2`
+    When I run `wp scaffold theme-tests twentytwelve`
     Then STDOUT should not be empty
-    And the {THEME_DIR}/p2/tests directory should contain:
+    And the {THEME_DIR}/twentytwelve/tests directory should contain:
       """
       bootstrap.php
       """


### PR DESCRIPTION
Replace P2 theme with TwentyTwelve in feature tests

Related https://github.com/wp-cli/wp-cli-tests/issues/200