### PR TITLE
Accept Bitbucket as valid CI in scaffold plugin

### DIFF
--- a/features/scaffold-plugin-tests.feature
+++ b/features/scaffold-plugin-tests.feature
@@ -309,3 +309,16 @@ Feature: Scaffold plugin unit tests
       """
       require dirname( dirname( __FILE__ ) ) . '/bar.php';
       """
+
+  Scenario: Accept bitbucket as valid CI in plugin scaffold
+    Given a WP install
+    When I run `wp plugin path`
+    Then save STDOUT as {PLUGIN_DIR}
+
+    When I run `wp scaffold plugin hello-world --ci=bitbucket`
+    Then STDOUT should not be empty
+    And the {PLUGIN_DIR}/hello-world/.editorconfig file should exist
+    And the {PLUGIN_DIR}/hello-world/hello-world.php file should exist
+    And the {PLUGIN_DIR}/hello-world/readme.txt file should exist
+    And the {PLUGIN_DIR}/hello-world/bitbucket-pipelines.yml file should exist
+    And the {PLUGIN_DIR}/hello-world/tests directory should exist

--- a/src/Scaffold_Command.php
+++ b/src/Scaffold_Command.php
@@ -608,6 +608,7 @@ class Scaffold_Command extends WP_CLI_Command {
 	 * options:
 	 *   - circle
 	 *   - gitlab
+	 *   - bitbucket
 	 *   - github
 	 * ---
 	 *


### PR DESCRIPTION
Currently `bitbucket` is not accepted in `--ci` in `scaffold plugin` but in `scaffold plugin-tests` we have already implemented `bitbucket` CI. So, this PR adds `bitbucket` as valid CI in `scaffold plugin` and related scenario in feature test.