### PR TITLE
Update templates for child theme scaffolding

### DIFF
--- a/src/Scaffold_Command.php
+++ b/src/Scaffold_Command.php
@@ -492,10 +492,10 @@ class Scaffold_Command extends WP_CLI_Command {
 			'theme_uri'  => '',
 		];
 
-		$data                               = wp_parse_args( $assoc_args, $defaults );
-		$data['slug']                       = $theme_slug;
-		$data['parent_theme_function_safe'] = str_replace( [ ' ', '-' ], '_', $data['parent_theme'] );
-		$data['description']                = ucfirst( $data['parent_theme'] ) . ' child theme.';
+		$data                = wp_parse_args( $assoc_args, $defaults );
+		$data['slug']        = $theme_slug;
+		$data['prefix_safe'] = str_replace( [ ' ', '-' ], '_', $theme_slug );
+		$data['description'] = ucfirst( $data['parent_theme'] ) . ' child theme.';
 
 		$theme_dir = WP_CONTENT_DIR . "/themes/{$theme_slug}";
 

--- a/templates/child_theme_functions.mustache
+++ b/templates/child_theme_functions.mustache
@@ -7,15 +7,17 @@
  * @package {{slug}}
  */
 
-add_action( 'wp_enqueue_scripts', '{{parent_theme_function_safe}}_parent_theme_enqueue_styles' );
+add_action( 'wp_enqueue_scripts', '{{prefix_safe}}_parent_theme_enqueue_styles' );
 
 /**
  * Enqueue scripts and styles.
  */
-function {{parent_theme_function_safe}}_parent_theme_enqueue_styles() {
-	wp_enqueue_style( '{{parent_theme}}-style', get_template_directory_uri() . '/style.css' );
-	wp_enqueue_style( '{{slug}}-style',
+function {{prefix_safe}}_parent_theme_enqueue_styles() {
+	wp_enqueue_style( '{{parent_theme}}-style', get_template_directory_uri() . '/style.css', array(), '0.1.0' );
+	wp_enqueue_style(
+		'{{slug}}-style',
 		get_stylesheet_directory_uri() . '/style.css',
-		[ '{{parent_theme}}-style' ]
+		array( '{{parent_theme}}-style' ),
+		'0.1.0'
 	);
 }


### PR DESCRIPTION
Related https://github.com/wp-cli/scaffold-command/issues/109

* Function prefix should be of child theme, not parent theme
* Fixed WPCS issues in the mustache template