### PR TITLE
PHPUnit template: convert deprecations to exceptions

### DIFF
--- a/templates/phpunit.xml.dist
+++ b/templates/phpunit.xml.dist
@@ -4,8 +4,9 @@
 	backupGlobals="false"
 	colors="true"
 	convertErrorsToExceptions="true"
-	convertNoticesToExceptions="true"
 	convertWarningsToExceptions="true"
+	convertNoticesToExceptions="true"
+	convertDeprecationsToExceptions="true"
 	>
 	<testsuites>
 		<testsuite name="testing">


### PR DESCRIPTION
Since PHPUnit 9.5.10 and 8.5.21, PHP deprecations are no longer converted to exceptions by default (`convertDeprecationsToExceptions="true"` can be configured to enable this).

This commit reverts PHPUnit to the previous behaviour by adding `convertDeprecationsToExceptions="true"` to the PHPUnit configuration. It also adds the other related directives for consistency.

See similar change in core: https://github.com/WordPress/wordpress-develop/commit/7c2b54e0275201a07c145de5c705545ef58ebda7