### PR TITLE
Tests: Improve Windows compatibility

### DIFF
--- a/features/install-wp-tests.feature
+++ b/features/install-wp-tests.feature
@@ -1,6 +1,8 @@
 # Note: You need to execute the mysql command `GRANT ALL PRIVILEGES ON wp_cli_test_scaffold.* TO "wp_cli_test"@"localhost" IDENTIFIED BY "{DB_PASSWORD}";` for these tests to work locally.
 Feature: Scaffold install-wp-tests.sh tests
 
+  # TODO: Fix this on Windows. Fails because /usr/bin/env bash is not available.
+  @skip-windows
   Scenario: Help should be displayed
     Given a WP install
     And I run `wp plugin path`

--- a/features/scaffold-plugin-tests.feature
+++ b/features/scaffold-plugin-tests.feature
@@ -220,10 +220,7 @@ Feature: Scaffold plugin unit tests
     Then the {RUN_DIR}/wp-content/plugins/foo.php file should exist
 
     When I try `wp scaffold plugin-tests foo`
-    Then STDERR should be:
-      """
-      Error: Invalid plugin slug specified. No such target directory '{RUN_DIR}/wp-content/plugins/foo'.
-      """
+    Then STDERR should match #Error: Invalid plugin slug specified\. No such target directory '.*wp-content/plugins/foo'\.#
     And the return code should be 1
 
     When I try `wp scaffold plugin-tests .`
@@ -271,10 +268,7 @@ Feature: Scaffold plugin unit tests
     When I run `rm -rf {PLUGIN_DIR} && touch {PLUGIN_DIR}`
     Then the return code should be 0
     When I try `wp scaffold plugin-tests hello-world`
-    Then STDERR should be:
-      """
-      Error: Invalid plugin slug specified. No such target directory '{PLUGIN_DIR}'.
-      """
+    Then STDERR should match #Error: Invalid plugin slug specified\. No such target directory '.*hello-world'\.#
     And the return code should be 1
 
   Scenario: Scaffold plugin tests with a symbolic link

--- a/features/scaffold-plugin-tests.feature
+++ b/features/scaffold-plugin-tests.feature
@@ -1,5 +1,7 @@
 Feature: Scaffold plugin unit tests
 
+  # TODO: Fix this on Windows. Fails because is_executable() fails for .sh files.
+  @skip-windows
   Scenario: Scaffold plugin tests
     Given a WP install
     When I run `wp plugin path`

--- a/features/scaffold-theme-tests.feature
+++ b/features/scaffold-theme-tests.feature
@@ -256,6 +256,8 @@ Feature: Scaffold theme unit tests
     When I run `rm -f {THEME_DIR}/twentytwelve && mv -f {THEME_DIR}/hide-twentytwelve {THEME_DIR}/twentytwelve`
     Then the return code should be 0
 
+  # TODO: Fix this on Windows. Fails because unlink fails on directories.
+  @skip-windows
   Scenario: Scaffold theme tests with a symbolic link
     # Temporarily move the whole theme dir and create a symbolic link to it.
     When I run `mv -f {THEME_DIR} {RUN_DIR}/alt-themes && ln -s {RUN_DIR}/alt-themes {THEME_DIR}`

--- a/src/Scaffold_Command.php
+++ b/src/Scaffold_Command.php
@@ -1008,6 +1008,8 @@ class Scaffold_Command extends WP_CLI_Command {
 				continue;
 			}
 
+			$contents = str_replace( "\r\n", "\n", $contents );
+
 			$wp_filesystem->mkdir( dirname( $filename ) );
 
 			// Create multi-level folders.


### PR DESCRIPTION
Fixes a macOS-specific failure caused by `/var` vs `/private/var` path expansion

<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->
