### PR TITLE
Fix child-theme/plugin path check when --path contains relative segments

### DIFF
--- a/src/Scaffold_Command.php
+++ b/src/Scaffold_Command.php
@@ -986,11 +986,11 @@ class Scaffold_Command extends WP_CLI_Command {
 	private function check_target_directory( $type, $target_dir ) {
 		$parent_dir = dirname( self::canonicalize_path( str_replace( '\\', '/', $target_dir ) ) );
 
-		if ( 'theme' === $type && str_replace( '\\', '/', WP_CONTENT_DIR . '/themes' ) !== $parent_dir ) {
+		if ( 'theme' === $type && self::canonicalize_path( str_replace( '\\', '/', WP_CONTENT_DIR . '/themes' ) ) !== $parent_dir ) {
 			return sprintf( 'The target directory \'%1$s\' is not in \'%2$s\'.', $target_dir, WP_CONTENT_DIR . '/themes' );
 		}
 
-		if ( 'plugin' === $type && str_replace( '\\', '/', WP_PLUGIN_DIR ) !== $parent_dir ) {
+		if ( 'plugin' === $type && self::canonicalize_path( str_replace( '\\', '/', WP_PLUGIN_DIR ) ) !== $parent_dir ) {
 			return sprintf( 'The target directory \'%1$s\' is not in \'%2$s\'.', $target_dir, WP_PLUGIN_DIR );
 		}
 


### PR DESCRIPTION
## Problem

Using `wp scaffold child-theme` with a `--path` argument that contains relative path segments (e.g. `--path=../mywpsite/`) fails with:

```
Error: Invalid theme slug specified. The target directory '.../../mywpsite/wp-content/themes/slug' is not in '.../../mywpsite/wp-content/themes'.
```

The same issue affects `scaffold plugin` and other subcommands that use `check_target_directory()`.

## Root Cause

In `check_target_directory()`, the `` is canonicalized (resolving `..` and `.` segments) before comparison, but the reference paths (`WP_CONTENT_DIR . '/themes'` and `WP_PLUGIN_DIR`) are **not** canonicalized. When `--path` contains relative segments, `WP_CONTENT_DIR` retains them unnormalized, causing the string comparison to fail even though both paths refer to the same directory.

## Fix

Apply `canonicalize_path()` to both sides of the comparison in `check_target_directory()` so paths are resolved consistently. This is a 2-line change.

Fixes #251