### PR TITLE
Reject invalid `Requires at least` header values

### DIFF
--- a/features/scaffold-plugin-tests.feature
+++ b/features/scaffold-plugin-tests.feature
@@ -143,6 +143,31 @@ Feature: Scaffold plugin unit tests
                   SKIP_DB_CREATE=true
       """
 
+  Scenario: Scaffold plugin tests ignores invalid version in readme.txt
+    Given a WP install
+    And I run `wp scaffold plugin hello-world --skip-tests`
+
+    When I run `wp plugin path hello-world --dir`
+    Then save STDOUT as {PLUGIN_DIR}
+
+    Given a {PLUGIN_DIR}/readme.txt file:
+      """
+      === Hello World ===
+      Requires at least: 6.4; echo exploit #
+      Tested up to: 6.4
+      """
+
+    When I run `wp scaffold plugin-tests hello-world --ci=circle`
+    Then STDOUT should not be empty
+    And the {PLUGIN_DIR}/.circleci/config.yml file should not contain:
+      """
+      6.4; echo exploit #
+      """
+    And the {PLUGIN_DIR}/.circleci/config.yml file should contain:
+      """
+                  bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest $SKIP_DB_CREATE
+      """
+
   Scenario: Scaffold plugin tests with Gitlab as the provider
     Given a WP install
     And I run `wp scaffold plugin hello-world --skip-tests`

--- a/features/scaffold-plugin-tests.feature
+++ b/features/scaffold-plugin-tests.feature
@@ -143,7 +143,7 @@ Feature: Scaffold plugin unit tests
                   SKIP_DB_CREATE=true
       """
 
-  Scenario: Scaffold plugin tests ignores invalid version in readme.txt
+  Scenario: Scaffold plugin tests ignore invalid version in readme.txt
     Given a WP install
     And I run `wp scaffold plugin hello-world --skip-tests`
 

--- a/src/Scaffold_Command.php
+++ b/src/Scaffold_Command.php
@@ -893,9 +893,11 @@ class Scaffold_Command extends WP_CLI_Command {
 		if ( file_exists( "{$target_dir}/readme.txt" ) ) {
 			$readme_content = (string) file_get_contents( "{$target_dir}/readme.txt" );
 
-			preg_match( '/Requires at least\:(.*)\n/m', $readme_content, $matches );
-			if ( isset( $matches[1] ) && $matches[1] ) {
-				$wp_versions_to_test[] = trim( $matches[1] );
+			if ( preg_match( '/Requires at least\:(.*)(?:\r?\n|$)/i', $readme_content, $matches ) ) {
+				$version = trim( $matches[1] );
+				if ( preg_match( '/^[0-9]+(?:\.[0-9]+)*(?:-[a-zA-Z0-9.]+)?$/', $version ) ) {
+					$wp_versions_to_test[] = $version;
+				}
 			}
 		}
 		$wp_versions_to_test[] = 'latest';


### PR DESCRIPTION
<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plugin readme file parsing to handle different line ending formats (CRLF and EOF).
  * Added validation to ensure only valid WordPress version formats are accepted for plugin requirements.

* **Tests**
  * Added test to verify malicious version specifications aren't injected into build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->